### PR TITLE
Consistent formatting

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+reorder_modules = true
+use_small_heuristics = "Max"

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,5 @@
 reorder_modules = true
 use_small_heuristics = "Max"
+ignore = [
+    "*/src/bindings.rs",
+]

--- a/README.md
+++ b/README.md
@@ -206,3 +206,7 @@ leaf timeline nodes. For now, our leaf node corresponds to tl_latest_event_to_st
 
 
 This is all still a work in progress, in terms of designing and implementing a well defined workflow with implementation of every DSL nodes in TimeLine.
+
+## Contributing
+
+RustRover and IntelliJ users should enable rustfmt instead of built-in formatter as described here: https://www.jetbrains.com/help/rust/rustfmt.html

--- a/core-stub/src/lib.rs
+++ b/core-stub/src/lib.rs
@@ -8,12 +8,8 @@ pub struct Api {
 impl Api {}
 impl crate::bindings::exports::timeline::core_stub::stub_core::GuestApi for Api {
     fn new(location: crate::bindings::golem::rpc::types::Uri) -> Self {
-        let location = golem_wasm_rpc::Uri {
-            value: location.value,
-        };
-        Self {
-            rpc: WasmRpc::new(&location),
-        }
+        let location = golem_wasm_rpc::Uri { value: location.value };
+        Self { rpc: WasmRpc::new(&location) }
     }
     fn initialize_timeline(
         &self,
@@ -401,10 +397,9 @@ impl crate::bindings::exports::timeline::core_stub::stub_core::GuestApi for Api 
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok({
-                        let record = ok_value.expect("result ok value not found");
-                        crate::bindings::timeline::core::api::WorkerDetails {
+                Ok(ok_value) => Ok({
+                    let record = ok_value.expect("result ok value not found");
+                    crate::bindings::timeline::core::api::WorkerDetails {
                             event_processor_workers: record
                                 .field(0usize)
                                 .expect("record field not found")
@@ -890,17 +885,12 @@ impl crate::bindings::exports::timeline::core_stub::stub_core::GuestApi for Api 
                                 }
                             },
                         }
-                    })
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                }),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }

--- a/core/src/builder.rs
+++ b/core/src/builder.rs
@@ -1,6 +1,10 @@
-use crate::bindings::exports::timeline::core::api::{NodeIndex, ServerWithEventColumnName, ServerWithEventPredicate, ServerWithEventPredicateWithin, TimelineConstantComparator, TimelineConstantCompared, TimelineNegated, TimelineNode, TimelineWithServer};
-use crate::conversions::Conversion;
 use crate::bindings::exports::timeline::core::api::TimelineOp as WitTimeLineOp;
+use crate::bindings::exports::timeline::core::api::{
+    NodeIndex, ServerWithEventColumnName, ServerWithEventPredicate, ServerWithEventPredicateWithin,
+    TimelineConstantComparator, TimelineConstantCompared, TimelineNegated, TimelineNode,
+    TimelineWithServer,
+};
+use crate::conversions::Conversion;
 use timeline::timeline_op::TimeLineOp;
 
 pub struct WitValueBuilder {
@@ -19,9 +23,7 @@ impl WitValueBuilder {
 
     // FIXME: Clone is not needed
     pub(crate) fn build(&self) -> WitTimeLineOp {
-       WitTimeLineOp {
-           nodes: self.nodes.clone()
-       }
+        WitTimeLineOp { nodes: self.nodes.clone() }
     }
 
     pub(crate) fn build_timeline_op(&mut self, timeline_op: &TimeLineOp) -> NodeIndex {
@@ -50,10 +52,8 @@ impl WitValueBuilder {
 
             TimeLineOp::Not(timeline_worker_input, timeline_op) => {
                 let server = timeline_worker_input.to_wit();
-                let parent_idx = self.add(TimelineNode::TimelineNegation(TimelineNegated {
-                    server,
-                    timeline: -1
-                }));
+                let parent_idx = self
+                    .add(TimelineNode::TimelineNegation(TimelineNegated { server, timeline: -1 }));
 
                 let child_idx = self.build_timeline_op(timeline_op);
 
@@ -67,12 +67,13 @@ impl WitValueBuilder {
             }
 
             TimeLineOp::GreaterThan(timeline_worker_input, timeline_op, golem_event_value) => {
-                let parent_idx = self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
-                    op: TimelineConstantComparator::GreaterThan,
-                    timeline: -1,
-                    value: golem_event_value.to_wit(),
-                    server: timeline_worker_input.to_wit()
-                }));
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::GreaterThan,
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
 
                 let child_idx = self.build_timeline_op(timeline_op);
 
@@ -86,13 +87,18 @@ impl WitValueBuilder {
                 parent_idx
             }
 
-            TimeLineOp::GreaterThanOrEqual(timeline_worker_input, timeline_op, golem_event_value) => {
-                let parent_idx = self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
-                    op: TimelineConstantComparator::GreaterThanEqual,
-                    timeline: -1,
-                    value: golem_event_value.to_wit(),
-                    server: timeline_worker_input.to_wit()
-                }));
+            TimeLineOp::GreaterThanOrEqual(
+                timeline_worker_input,
+                timeline_op,
+                golem_event_value,
+            ) => {
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::GreaterThanEqual,
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
 
                 let child_idx = self.build_timeline_op(timeline_op);
 
@@ -107,12 +113,13 @@ impl WitValueBuilder {
             }
 
             TimeLineOp::LessThan(timeline_worker_input, timeline_op, golem_event_value) => {
-                let parent_idx = self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
-                    op: TimelineConstantComparator::LessThan,
-                    timeline: -1,
-                    value: golem_event_value.to_wit(),
-                    server: timeline_worker_input.to_wit()
-                }));
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::LessThan,
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
 
                 let child_idx = self.build_timeline_op(timeline_op);
 
@@ -127,12 +134,13 @@ impl WitValueBuilder {
             }
 
             TimeLineOp::LessThanOrEqual(timeline_worker_input, timeline_op, golem_event_value) => {
-                let parent_idx = self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
-                    op: TimelineConstantComparator::LessThanEqual,
-                    timeline: -1,
-                    value: golem_event_value.to_wit(),
-                    server: timeline_worker_input.to_wit()
-                }));
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::LessThanEqual,
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
 
                 let child_idx = self.build_timeline_op(timeline_op);
 
@@ -147,12 +155,13 @@ impl WitValueBuilder {
             }
 
             TimeLineOp::EqualTo(timeline_worker_input, timeline_op, golem_event_value) => {
-                let parent_idx = self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
-                    op: TimelineConstantComparator::GreaterThan, // FIXME: Add Equal to ConstantOp
-                    timeline: -1,
-                    value: golem_event_value.to_wit(),
-                    server: timeline_worker_input.to_wit()
-                }));
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::GreaterThan, // FIXME: Add Equal to ConstantOp
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
 
                 let child_idx = self.build_timeline_op(timeline_op);
 
@@ -167,9 +176,9 @@ impl WitValueBuilder {
             }
 
             TimeLineOp::TlDurationInCurState(timeline_worker_input, timeline_op) => {
-                let parent_idx = self.add(TimelineNode::TlDurationInCurState(TimelineWithServer{
+                let parent_idx = self.add(TimelineNode::TlDurationInCurState(TimelineWithServer {
                     server: timeline_worker_input.to_wit(),
-                    timeline: -1
+                    timeline: -1,
                 }));
 
                 let child_idx = self.build_timeline_op(timeline_op);
@@ -185,9 +194,9 @@ impl WitValueBuilder {
             }
 
             TimeLineOp::TlDurationWhere(timeline_worker_input, timeline_op) => {
-                let parent_idx = self.add(TimelineNode::TlDurationWhere(TimelineWithServer{
+                let parent_idx = self.add(TimelineNode::TlDurationWhere(TimelineWithServer {
                     server: timeline_worker_input.to_wit(),
-                    timeline: -1
+                    timeline: -1,
                 }));
 
                 let child_idx = self.build_timeline_op(timeline_op);
@@ -201,22 +210,20 @@ impl WitValueBuilder {
 
                 parent_idx
             }
-            TimeLineOp::TlHasExistedWithin(timeline_worker_input, event_predicate, time) => {
-                self.add(TimelineNode::TlHasExistedWithin(ServerWithEventPredicateWithin {
+            TimeLineOp::TlHasExistedWithin(timeline_worker_input, event_predicate, time) => self
+                .add(TimelineNode::TlHasExistedWithin(ServerWithEventPredicateWithin {
                     filtered: ServerWithEventPredicate {
                         server: timeline_worker_input.to_wit(),
-                        event_predicate: event_predicate.to_wit()
+                        event_predicate: event_predicate.to_wit(),
                     },
-                    time: *time
-                }))
-            }
+                    time: *time,
+                })),
             TimeLineOp::And(timeline_worker_input, timeline_op1, timeline_op2) => {
                 unimplemented!("And") //FIXME
             }
             TimeLineOp::Or(_, _, _) => {
                 unimplemented!("Or") //FIXME
             }
-
         }
     }
 }

--- a/core/src/conversions.rs
+++ b/core/src/conversions.rs
@@ -115,10 +115,7 @@ impl Conversion for TypedTimeLineResultWorker {
                     let component_id = time_line_worker.component_id.clone();
                     let worker_id = time_line_worker.worker_id.0.clone();
                     WitTypedTimeLineResultWorker::LeafTimeline(WitLeafTimeLineNode::TlHasExisted(
-                        WitTimeLineResultWorker {
-                            template_id: component_id,
-                            worker_id,
-                        },
+                        WitTimeLineResultWorker { template_id: component_id, worker_id },
                     ))
                 }
                 LeafTimeLineNode::TLHasExistedWithin { time_line_worker } => {
@@ -203,10 +200,7 @@ impl Conversion for TypedTimeLineResultWorker {
                         let component_id = result_worker.component_id.clone();
                         let worker_id = result_worker.worker_id.0.clone();
                         WitTypedTimeLineResultWorker::DerivedTimeline(WitDerivedTimeLineNode::And(
-                            WitTimeLineResultWorker {
-                                template_id: component_id,
-                                worker_id,
-                            },
+                            WitTimeLineResultWorker { template_id: component_id, worker_id },
                         ))
                     }
                     DerivedTimeLineNode::Or { result_worker } => {
@@ -224,10 +218,7 @@ impl Conversion for TypedTimeLineResultWorker {
                         let component_id = result_worker.component_id.clone();
                         let worker_id = result_worker.worker_id.0.clone();
                         WitTypedTimeLineResultWorker::DerivedTimeline(WitDerivedTimeLineNode::Not(
-                            WitTimeLineResultWorker {
-                                template_id: component_id,
-                                worker_id,
-                            },
+                            WitTimeLineResultWorker { template_id: component_id, worker_id },
                         ))
                     }
                 }
@@ -406,10 +397,7 @@ mod internals {
                 );
 
                 let filter = GolemEventPredicate::from_wit(
-                    server_with_event_predicate_within
-                        .filtered
-                        .event_predicate
-                        .clone(),
+                    server_with_event_predicate_within.filtered.event_predicate.clone(),
                 );
 
                 TimeLineOp::TlHasExistedWithin(server, filter, max_duration)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -43,9 +43,7 @@ impl Guest for Component {
                     let worker_id =
                         TimeLineWorkerId(format!("{}-tleq-{}", worker_id_prefix, uuid.to_string()));
 
-                    let uri = Uri {
-                        value: format!("worker://{component_id}/{}", &worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{component_id}/{}", &worker_id) };
 
                     let timeline_processor_api = stub_timeline_processor::Api::new(&uri);
 
@@ -57,10 +55,7 @@ impl Guest for Component {
 
                     // The worker in which the comparison with a constant actually executes
                     let typed_timeline_result_worker = TypedTimeLineResultWorker::equal_to({
-                        TimeLineResultWorker {
-                            component_id: component_id.clone(),
-                            worker_id,
-                        }
+                        TimeLineResultWorker { component_id: component_id.clone(), worker_id }
                     });
 
                     Ok(typed_timeline_result_worker)
@@ -74,9 +69,7 @@ impl Guest for Component {
                     let worker_id =
                         TimeLineWorkerId(format!("{}-tlgt-{}", worker_id_prefix, uuid.to_string()));
 
-                    let uri = Uri {
-                        value: format!("worker://{component_id}/{}", &worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{component_id}/{}", &worker_id) };
 
                     let timeline_processor_api = stub_timeline_processor::Api::new(&uri);
 
@@ -89,10 +82,7 @@ impl Guest for Component {
 
                     // The worker in which the comparison with a constant actually executes
                     let typed_timeline_result_worker = TypedTimeLineResultWorker::greater_than({
-                        TimeLineResultWorker {
-                            component_id: component_id.clone(),
-                            worker_id,
-                        }
+                        TimeLineResultWorker { component_id: component_id.clone(), worker_id }
                     });
 
                     Ok(typed_timeline_result_worker)
@@ -109,9 +99,7 @@ impl Guest for Component {
                         uuid.to_string()
                     ));
 
-                    let uri = Uri {
-                        value: format!("worker://{template_id}/{}", &worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{template_id}/{}", &worker_id) };
 
                     let timeline_processor_api = stub_timeline_processor::Api::new(&uri);
 
@@ -127,10 +115,7 @@ impl Guest for Component {
                     // The worker in which the comparison with a constant actually executes
                     let typed_timeline_result_worker =
                         TypedTimeLineResultWorker::greater_than_or_equal_to({
-                            TimeLineResultWorker {
-                                component_id: template_id.clone(),
-                                worker_id,
-                            }
+                            TimeLineResultWorker { component_id: template_id.clone(), worker_id }
                         });
 
                     Ok(typed_timeline_result_worker)
@@ -144,9 +129,7 @@ impl Guest for Component {
                     let worker_id =
                         TimeLineWorkerId(format!("{}-tllt-{}", worker_id_prefix, uuid.to_string()));
 
-                    let uri = Uri {
-                        value: format!("worker://{template_id}/{}", &worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{template_id}/{}", &worker_id) };
 
                     let timeline_processor_api = stub_timeline_processor::Api::new(&uri);
 
@@ -159,10 +142,7 @@ impl Guest for Component {
 
                     // The worker in which the comparison with a constant actually executes
                     let typed_timeline_result_worker = TypedTimeLineResultWorker::greater_than({
-                        TimeLineResultWorker {
-                            component_id: template_id.clone(),
-                            worker_id,
-                        }
+                        TimeLineResultWorker { component_id: template_id.clone(), worker_id }
                     });
 
                     Ok(typed_timeline_result_worker)
@@ -179,9 +159,7 @@ impl Guest for Component {
                         uuid.to_string()
                     ));
 
-                    let uri = Uri {
-                        value: format!("worker://{template_id}/{}", &worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{template_id}/{}", &worker_id) };
 
                     let timeline_processor_api = stub_timeline_processor::Api::new(&uri);
 
@@ -196,10 +174,7 @@ impl Guest for Component {
                     // The worker in which the comparison with a constant actually executes
                     let typed_timeline_result_worker =
                         TypedTimeLineResultWorker::less_than_or_equal_to({
-                            TimeLineResultWorker {
-                                component_id: template_id.clone(),
-                                worker_id,
-                            }
+                            TimeLineResultWorker { component_id: template_id.clone(), worker_id }
                         });
 
                     Ok(typed_timeline_result_worker)
@@ -215,9 +190,7 @@ impl Guest for Component {
                         uuid.to_string()
                     ));
 
-                    let uri = Uri {
-                        value: format!("worker://{template_id}/{}", &worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{template_id}/{}", &worker_id) };
 
                     let core = stub_timeline_processor::Api::new(&uri);
 
@@ -229,10 +202,7 @@ impl Guest for Component {
 
                     // The result of this node will be available in this worker
                     let typed_timeline_result_worker = TypedTimeLineResultWorker::and({
-                        TimeLineResultWorker {
-                            component_id: template_id.clone(),
-                            worker_id,
-                        }
+                        TimeLineResultWorker { component_id: template_id.clone(), worker_id }
                     });
 
                     Ok(typed_timeline_result_worker)
@@ -248,9 +218,7 @@ impl Guest for Component {
                         uuid.to_string()
                     ));
 
-                    let uri = Uri {
-                        value: format!("worker://{template_id}/{}", &worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{template_id}/{}", &worker_id) };
 
                     let core = stub_timeline_processor::Api::new(&uri);
 
@@ -262,10 +230,7 @@ impl Guest for Component {
 
                     // The result of this node will be available in this worker
                     let typed_timeline_result_worker = TypedTimeLineResultWorker::or({
-                        TimeLineResultWorker {
-                            component_id: template_id.clone(),
-                            worker_id,
-                        }
+                        TimeLineResultWorker { component_id: template_id.clone(), worker_id }
                     });
 
                     Ok(typed_timeline_result_worker)
@@ -281,9 +246,7 @@ impl Guest for Component {
                         uuid.to_string()
                     ));
 
-                    let uri = Uri {
-                        value: format!("worker://{template_id}/{}", &worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{template_id}/{}", &worker_id) };
 
                     let core = stub_timeline_processor::Api::new(&uri);
 
@@ -294,10 +257,7 @@ impl Guest for Component {
 
                     // The result of this node will be available in this worker
                     let typed_timeline_result_worker = TypedTimeLineResultWorker::not({
-                        TimeLineResultWorker {
-                            component_id: template_id.clone(),
-                            worker_id,
-                        }
+                        TimeLineResultWorker { component_id: template_id.clone(), worker_id }
                     });
 
                     Ok(typed_timeline_result_worker)
@@ -310,9 +270,7 @@ impl Guest for Component {
                     let worker_id =
                         TimeLineWorkerId(format!("{}-tlhe-{}", worker_id_prefix, uuid.to_string()));
 
-                    let uri = Uri {
-                        value: format!("worker://{template_id}/{}", &worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{template_id}/{}", &worker_id) };
 
                     let core = stub_event_processor::Api::new(&uri);
 
@@ -320,10 +278,7 @@ impl Guest for Component {
 
                     // The result of this node will be available in this worker
                     let typed_timeline_result_worker = TypedTimeLineResultWorker::tl_has_existed({
-                        TimeLineResultWorker {
-                            component_id: template_id.clone(),
-                            worker_id,
-                        }
+                        TimeLineResultWorker { component_id: template_id.clone(), worker_id }
                     });
 
                     event_processors.push(typed_timeline_result_worker.to_wit());
@@ -341,9 +296,7 @@ impl Guest for Component {
                         uuid.to_string()
                     ));
 
-                    let uri = Uri {
-                        value: format!("worker://{template_id}/{}", worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{template_id}/{}", worker_id) };
 
                     let core = stub_event_processor::Api::new(&uri);
 
@@ -353,10 +306,7 @@ impl Guest for Component {
                     // The result of this node will be available in this worker
                     let typed_timeline_result_worker =
                         TypedTimeLineResultWorker::tl_has_existed_within({
-                            TimeLineResultWorker {
-                                component_id: template_id.clone(),
-                                worker_id,
-                            }
+                            TimeLineResultWorker { component_id: template_id.clone(), worker_id }
                         });
 
                     event_processors.push(typed_timeline_result_worker.to_wit());
@@ -371,9 +321,7 @@ impl Guest for Component {
                         worker_id_prefix, event_column_name
                     ));
 
-                    let uri = Uri {
-                        value: format!("worker://{template_id}/{}", worker_id),
-                    };
+                    let uri = Uri { value: format!("worker://{template_id}/{}", worker_id) };
 
                     let core = stub_event_processor::Api::new(&uri);
 
@@ -382,10 +330,7 @@ impl Guest for Component {
                     // The result of this node will be available in this worker
                     let typed_timeline_result_worker =
                         TypedTimeLineResultWorker::tl_has_existed_within({
-                            TimeLineResultWorker {
-                                component_id: template_id.clone(),
-                                worker_id,
-                            }
+                            TimeLineResultWorker { component_id: template_id.clone(), worker_id }
                         });
 
                     event_processors.push(typed_timeline_result_worker.to_wit());
@@ -400,9 +345,6 @@ impl Guest for Component {
         let result_worker = go(&timeline, &mut event_processor_workers)
             .map(|typed_worker_info| typed_worker_info.to_wit())?;
 
-        Ok(WorkerDetails {
-            result_worker,
-            event_processor_workers,
-        })
+        Ok(WorkerDetails { result_worker, event_processor_workers })
     }
 }

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -23,9 +23,7 @@ impl Guest for Component {
         event_processor_template_id: String,
         timeline_processor_template_id: String,
     ) -> Result<WorkerDetails, String> {
-        let uri = Uri {
-            value: format!("worker://{core_template_id}/{}", "initialize-timeline"),
-        };
+        let uri = Uri { value: format!("worker://{core_template_id}/{}", "initialize-timeline") };
 
         let core = stub_core::Api::new(&uri);
         let timeline_op = TimelineOp {

--- a/event-processor-stub/src/lib.rs
+++ b/event-processor-stub/src/lib.rs
@@ -7,31 +7,23 @@ pub struct Api {
 }
 impl Api {}
 impl crate::bindings::exports::timeline::event_processor_stub::stub_event_processor::GuestApi
-for Api {
+    for Api
+{
     fn new(location: crate::bindings::golem::rpc::types::Uri) -> Self {
-        let location = golem_wasm_rpc::Uri {
-            value: location.value,
-        };
-        Self {
-            rpc: WasmRpc::new(&location),
-        }
+        let location = golem_wasm_rpc::Uri { value: location.value };
+        Self { rpc: WasmRpc::new(&location) }
     }
-    fn initialize_latest_event_state(
-        &self,
-        event_col_name: String,
-    ) -> Result<String, String> {
+    fn initialize_latest_event_state(&self, event_col_name: String) -> Result<String, String> {
         let result = self
             .rpc
             .invoke_and_await(
                 "timeline:event-processor/api/initialize-latest-event-state",
                 &[WitValue::builder().string(&event_col_name)],
             )
-            .expect(
-                &format!(
-                    "Failed to invoke remote {}",
-                    "timeline:event-processor/api/initialize-latest-event-state"
-                ),
-            );
+            .expect(&format!(
+                "Failed to invoke remote {}",
+                "timeline:event-processor/api/initialize-latest-event-state"
+            ));
         ({
             let result = result
                 .tuple_element(0)
@@ -39,24 +31,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -148,24 +132,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -259,24 +235,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -365,46 +333,33 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
     fn latest_event_to_state(
         &self,
         t1: u64,
-    ) -> Result<
-        crate::bindings::timeline::event_processor::api::TimelineResult,
-        String,
-    > {
+    ) -> Result<crate::bindings::timeline::event_processor::api::TimelineResult, String> {
         let result = self
             .rpc
             .invoke_and_await(
                 "timeline:event-processor/api/latest-event-to-state",
                 &[WitValue::builder().u64(t1)],
             )
-            .expect(
-                &format!(
-                    "Failed to invoke remote {}",
-                    "timeline:event-processor/api/latest-event-to-state"
-                ),
-            );
+            .expect(&format!(
+                "Failed to invoke remote {}",
+                "timeline:event-processor/api/latest-event-to-state"
+            ));
         ({
             let result = result
                 .tuple_element(0)
@@ -412,10 +367,9 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok({
-                        let record = ok_value.expect("result ok value not found");
-                        crate::bindings::timeline::event_processor::api::TimelineResult {
+                Ok(ok_value) => Ok({
+                    let record = ok_value.expect("result ok value not found");
+                    crate::bindings::timeline::event_processor::api::TimelineResult {
                             results: record
                                 .field(0usize)
                                 .expect("record field not found")
@@ -486,39 +440,29 @@ for Api {
                                 })
                                 .expect("list not found"),
                         }
-                    })
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                }),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
     fn tl_has_existed(
         &self,
         t1: u64,
-    ) -> Result<
-        crate::bindings::timeline::event_processor::api::TimelineResult,
-        String,
-    > {
+    ) -> Result<crate::bindings::timeline::event_processor::api::TimelineResult, String> {
         let result = self
             .rpc
             .invoke_and_await(
                 "timeline:event-processor/api/tl-has-existed",
                 &[WitValue::builder().u64(t1)],
             )
-            .expect(
-                &format!(
-                    "Failed to invoke remote {}",
-                    "timeline:event-processor/api/tl-has-existed"
-                ),
-            );
+            .expect(&format!(
+                "Failed to invoke remote {}",
+                "timeline:event-processor/api/tl-has-existed"
+            ));
         ({
             let result = result
                 .tuple_element(0)
@@ -526,10 +470,9 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok({
-                        let record = ok_value.expect("result ok value not found");
-                        crate::bindings::timeline::event_processor::api::TimelineResult {
+                Ok(ok_value) => Ok({
+                    let record = ok_value.expect("result ok value not found");
+                    crate::bindings::timeline::event_processor::api::TimelineResult {
                             results: record
                                 .field(0usize)
                                 .expect("record field not found")
@@ -600,39 +543,29 @@ for Api {
                                 })
                                 .expect("list not found"),
                         }
-                    })
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                }),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
     fn tl_has_existed_within(
         &self,
         t1: u64,
-    ) -> Result<
-        crate::bindings::timeline::event_processor::api::TimelineResult,
-        String,
-    > {
+    ) -> Result<crate::bindings::timeline::event_processor::api::TimelineResult, String> {
         let result = self
             .rpc
             .invoke_and_await(
                 "timeline:event-processor/api/tl-has-existed-within",
                 &[WitValue::builder().u64(t1)],
             )
-            .expect(
-                &format!(
-                    "Failed to invoke remote {}",
-                    "timeline:event-processor/api/tl-has-existed-within"
-                ),
-            );
+            .expect(&format!(
+                "Failed to invoke remote {}",
+                "timeline:event-processor/api/tl-has-existed-within"
+            ));
         ({
             let result = result
                 .tuple_element(0)
@@ -640,10 +573,9 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok({
-                        let record = ok_value.expect("result ok value not found");
-                        crate::bindings::timeline::event_processor::api::TimelineResult {
+                Ok(ok_value) => Ok({
+                    let record = ok_value.expect("result ok value not found");
+                    crate::bindings::timeline::event_processor::api::TimelineResult {
                             results: record
                                 .field(0usize)
                                 .expect("record field not found")
@@ -714,17 +646,12 @@ for Api {
                                 })
                                 .expect("list not found"),
                         }
-                    })
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                }),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }

--- a/event-processor/src/conversions.rs
+++ b/event-processor/src/conversions.rs
@@ -77,25 +77,17 @@ impl Conversion for GolemEvent<GolemEventValue> {
     type WitType = Event;
 
     fn from_wit(input: Self::WitType) -> Self {
-        let mut event = GolemEvent {
-            time: input.time,
-            event: HashMap::new(),
-        };
+        let mut event = GolemEvent { time: input.time, event: HashMap::new() };
 
         for (key, value) in input.event {
-            event
-                .event
-                .insert(EventColumnName(key), GolemEventValue::from_wit(value));
+            event.event.insert(EventColumnName(key), GolemEventValue::from_wit(value));
         }
 
         event
     }
 
     fn to_wit(&self) -> Self::WitType {
-        let mut event = Event {
-            time: self.time,
-            event: vec![],
-        };
+        let mut event = Event { time: self.time, event: vec![] };
 
         for (key, value) in self.event.iter() {
             event.event.push((key.0.clone(), value.to_wit()));

--- a/event-processor/src/lib.rs
+++ b/event-processor/src/lib.rs
@@ -128,10 +128,8 @@ impl Guest for Component {
     fn add_event(event: Event) -> Result<String, String> {
         with_latest_event_to_state(|state| {
             if let Some(state_col_name) = state.col_name.as_ref() {
-                let event_value = event
-                    .event
-                    .iter()
-                    .find(|(key, _)| key == state_col_name.0.as_str());
+                let event_value =
+                    event.event.iter().find(|(key, _)| key == state_col_name.0.as_str());
 
                 match event_value {
                     Some((_, value)) => {
@@ -146,10 +144,7 @@ impl Guest for Component {
                         );
                     }
                     None => {
-                        dbg!(
-                            "No event value found for the column name: {}",
-                            &state_col_name.0
-                        );
+                        dbg!("No event value found for the column name: {}", &state_col_name.0);
                     }
                 }
             };
@@ -172,16 +167,12 @@ impl Guest for Component {
                             "Setting timeline as true from time {} since the predicate is true!",
                             event.time
                         );
-                        state
-                            .state_dynamic_timeline
-                            .add_state_dynamic_info(event.time, true);
+                        state.state_dynamic_timeline.add_state_dynamic_info(event.time, true);
                     } else {
                         // If predicate is false, and if the future is not yet set to false, then set it to false once and for all
                         if !state.state_dynamic_timeline.future_is(false) {
                             dbg!("Setting timeline as false from time {} since the predicate is false!", event.time);
-                            state
-                                .state_dynamic_timeline
-                                .add_state_dynamic_info(event.time, false);
+                            state.state_dynamic_timeline.add_state_dynamic_info(event.time, false);
                         }
                     }
                 }
@@ -198,18 +189,15 @@ impl Guest for Component {
                 if state.state_dynamic_timeline.is_empty()
                     || state.state_dynamic_timeline.future_is(false)
                 {
-                    let predicate_result = predicate_within
-                        .predicate
-                        .evaluate(&GolemEvent::from_wit(event.clone()));
+                    let predicate_result =
+                        predicate_within.predicate.evaluate(&GolemEvent::from_wit(event.clone()));
 
                     if predicate_result {
                         dbg!(
                             "Setting timeline as true from time {} since the predicate is true!",
                             event.time
                         );
-                        state
-                            .state_dynamic_timeline
-                            .add_state_dynamic_info(event.time, true);
+                        state.state_dynamic_timeline.add_state_dynamic_info(event.time, true);
 
                         state
                             .state_dynamic_timeline
@@ -218,9 +206,7 @@ impl Guest for Component {
                         // If predicate is false, and if the future is not yet set to false, then set it to false once and for all
                         if !state.state_dynamic_timeline.future_is(false) {
                             dbg!("Setting timeline as false from time {} since the predicate is false!", event.time);
-                            state
-                                .state_dynamic_timeline
-                                .add_state_dynamic_info(event.time, false);
+                            state.state_dynamic_timeline.add_state_dynamic_info(event.time, false);
                         }
                     }
                 }

--- a/timeline-processor-stub/src/lib.rs
+++ b/timeline-processor-stub/src/lib.rs
@@ -7,14 +7,11 @@ pub struct Api {
 }
 impl Api {}
 impl crate::bindings::exports::timeline::timeline_processor_stub::stub_timeline_processor::GuestApi
-for Api {
+    for Api
+{
     fn new(location: crate::bindings::golem::rpc::types::Uri) -> Self {
-        let location = golem_wasm_rpc::Uri {
-            value: location.value,
-        };
-        Self {
-            rpc: WasmRpc::new(&location),
-        }
+        let location = golem_wasm_rpc::Uri { value: location.value };
+        Self { rpc: WasmRpc::new(&location) }
     }
     fn initialize_equal(
         &self,
@@ -320,24 +317,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -645,24 +634,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -970,24 +951,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -1295,24 +1268,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -1620,24 +1585,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -2134,24 +2091,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -2648,24 +2597,16 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
@@ -2927,46 +2868,33 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok(
-                        ok_value
-                            .expect("result ok value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                Ok(ok_value) => Ok(ok_value
+                    .expect("result ok value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }
     fn get_timeline_result(
         &self,
         t1: u64,
-    ) -> Result<
-        crate::bindings::timeline::timeline_processor::api::TimelineResult,
-        String,
-    > {
+    ) -> Result<crate::bindings::timeline::timeline_processor::api::TimelineResult, String> {
         let result = self
             .rpc
             .invoke_and_await(
                 "timeline:timeline-processor/api/get-timeline-result",
                 &[WitValue::builder().u64(t1)],
             )
-            .expect(
-                &format!(
-                    "Failed to invoke remote {}",
-                    "timeline:timeline-processor/api/get-timeline-result"
-                ),
-            );
+            .expect(&format!(
+                "Failed to invoke remote {}",
+                "timeline:timeline-processor/api/get-timeline-result"
+            ));
         ({
             let result = result
                 .tuple_element(0)
@@ -2974,10 +2902,9 @@ for Api {
                 .result()
                 .expect("result not found");
             match result {
-                Ok(ok_value) => {
-                    Ok({
-                        let record = ok_value.expect("result ok value not found");
-                        crate::bindings::timeline::event_processor::api::TimelineResult {
+                Ok(ok_value) => Ok({
+                    let record = ok_value.expect("result ok value not found");
+                    crate::bindings::timeline::event_processor::api::TimelineResult {
                             results: record
                                 .field(0usize)
                                 .expect("record field not found")
@@ -3048,17 +2975,12 @@ for Api {
                                 })
                                 .expect("list not found"),
                         }
-                    })
-                }
-                Err(err_value) => {
-                    Err(
-                        err_value
-                            .expect("result err value not found")
-                            .string()
-                            .expect("string not found")
-                            .to_string(),
-                    )
-                }
+                }),
+                Err(err_value) => Err(err_value
+                    .expect("result err value not found")
+                    .string()
+                    .expect("string not found")
+                    .to_string()),
             }
         })
     }

--- a/timeline-processor/src/conversions.rs
+++ b/timeline-processor/src/conversions.rs
@@ -1,8 +1,10 @@
+use crate::bindings::timeline::event_processor::api::{
+    EventValue, TimePeriod, TimelineResult, TimelineResultPoint,
+};
 use std::fmt::Debug;
 use timeline::golem_event::GolemEventValue;
 use timeline::state_dynamic_timeline::StateDynamicsTimeLine;
 use timeline::state_dynamic_timeline_point::StateDynamicsTimeLinePoint;
-use crate::bindings::timeline::event_processor::api::{EventValue, TimelineResult, TimelineResultPoint, TimePeriod};
 
 pub trait Conversion: Clone + Debug {
     type WitType: Clone;
@@ -30,7 +32,6 @@ impl Conversion for GolemEventValue {
             GolemEventValue::BoolValue(b) => EventValue::BoolValue(b.clone()),
         }
     }
-
 }
 
 impl Conversion for StateDynamicsTimeLinePoint<GolemEventValue> {
@@ -46,10 +47,7 @@ impl Conversion for StateDynamicsTimeLinePoint<GolemEventValue> {
 
     fn to_wit(&self) -> Self::WitType {
         TimelineResultPoint {
-            time_period: TimePeriod {
-                t1: self.t1,
-                t2: self.t2.unwrap(),
-            },
+            time_period: TimePeriod { t1: self.t1, t2: self.t2.unwrap() },
             value: self.value.to_wit(),
         }
     }
@@ -60,13 +58,15 @@ impl Conversion for StateDynamicsTimeLine<GolemEventValue> {
 
     fn from_wit(input: Self::WitType) -> Self {
         StateDynamicsTimeLine::from(
-            input.results.iter().map(|point| StateDynamicsTimeLinePoint::from_wit(point.clone())).collect(),
+            input
+                .results
+                .iter()
+                .map(|point| StateDynamicsTimeLinePoint::from_wit(point.clone()))
+                .collect(),
         )
     }
 
     fn to_wit(&self) -> Self::WitType {
-        TimelineResult {
-            results: self.points.iter().map(|point| point.1.to_wit()).collect(),
-        }
+        TimelineResult { results: self.points.iter().map(|point| point.1.to_wit()).collect() }
     }
 }

--- a/timeline-processor/src/extensions.rs
+++ b/timeline-processor/src/extensions.rs
@@ -1,4 +1,6 @@
-use crate::bindings::exports::timeline::timeline_processor::api::{DerivedTimelineNode, LeafTimelineNode, TimelineResultWorker, TypedTimelineResultWorker};
+use crate::bindings::exports::timeline::timeline_processor::api::{
+    DerivedTimelineNode, LeafTimelineNode, TimelineResultWorker, TypedTimelineResultWorker,
+};
 use crate::bindings::golem::rpc::types::Uri;
 use crate::bindings::timeline::event_processor::api::TimelineResult;
 use crate::bindings::timeline::event_processor_stub::stub_event_processor;
@@ -6,7 +8,6 @@ use crate::bindings::timeline::timeline_processor_stub::stub_timeline_processor;
 
 pub(crate) trait WorkerExt {
     fn get_worker_info(&self) -> WorkerInfo;
-
 }
 
 struct WorkerInfo {
@@ -16,18 +17,13 @@ struct WorkerInfo {
 
 impl WorkerInfo {
     pub fn get_uri(&self) -> Uri {
-        Uri {
-            value: format!("worker://{}/{}", self.template_id, self.worker_id),
-        }
+        Uri { value: format!("worker://{}/{}", self.template_id, self.worker_id) }
     }
 }
 
 impl WorkerExt for TimelineResultWorker {
     fn get_worker_info(&self) -> WorkerInfo {
-        WorkerInfo {
-            worker_id: self.worker_id.clone(),
-            template_id: self.template_id.clone(),
-        }
+        WorkerInfo { worker_id: self.worker_id.clone(), template_id: self.template_id.clone() }
     }
 }
 
@@ -35,25 +31,29 @@ impl WorkerExt for TypedTimelineResultWorker {
     // FIXME: Fix the data structure of TypedTimeLineResultWorker as a product of TimeLineResultWorker and enum of timeline type
     fn get_worker_info(&self) -> WorkerInfo {
         match self {
-            TypedTimelineResultWorker::DerivedTimeline(timeline) => {
-                match timeline {
-                    DerivedTimelineNode::EqualTo(result_worker) => result_worker.get_worker_info(),
-                    DerivedTimelineNode::GreaterThan(result_worker) => result_worker.get_worker_info(),
-                    DerivedTimelineNode::GreaterThanOrEqualTo(result_worker) => result_worker.get_worker_info(),
-                    DerivedTimelineNode::LessThan(result_worker) => result_worker.get_worker_info(),
-                    DerivedTimelineNode::LessThanOrEqualTo(result_worker) => result_worker.get_worker_info(),
-                    DerivedTimelineNode::And(result_worker) => result_worker.get_worker_info(),
-                    DerivedTimelineNode::Or(result_worker) => result_worker.get_worker_info(),
-                    DerivedTimelineNode::Not(result_worker) => result_worker.get_worker_info()
+            TypedTimelineResultWorker::DerivedTimeline(timeline) => match timeline {
+                DerivedTimelineNode::EqualTo(result_worker) => result_worker.get_worker_info(),
+                DerivedTimelineNode::GreaterThan(result_worker) => result_worker.get_worker_info(),
+                DerivedTimelineNode::GreaterThanOrEqualTo(result_worker) => {
+                    result_worker.get_worker_info()
                 }
-            }
-            TypedTimelineResultWorker::LeafTimeline(timeline) => {
-                match timeline {
-                    LeafTimelineNode::TlHasExisted(result_worker) => result_worker.get_worker_info(),
-                    LeafTimelineNode::TlHasExistedWithin(result_worker) => result_worker.get_worker_info(),
-                    LeafTimelineNode::TlLatestEventToState(result_worker) => result_worker.get_worker_info()
+                DerivedTimelineNode::LessThan(result_worker) => result_worker.get_worker_info(),
+                DerivedTimelineNode::LessThanOrEqualTo(result_worker) => {
+                    result_worker.get_worker_info()
                 }
-            }
+                DerivedTimelineNode::And(result_worker) => result_worker.get_worker_info(),
+                DerivedTimelineNode::Or(result_worker) => result_worker.get_worker_info(),
+                DerivedTimelineNode::Not(result_worker) => result_worker.get_worker_info(),
+            },
+            TypedTimelineResultWorker::LeafTimeline(timeline) => match timeline {
+                LeafTimelineNode::TlHasExisted(result_worker) => result_worker.get_worker_info(),
+                LeafTimelineNode::TlHasExistedWithin(result_worker) => {
+                    result_worker.get_worker_info()
+                }
+                LeafTimelineNode::TlLatestEventToState(result_worker) => {
+                    result_worker.get_worker_info()
+                }
+            },
         }
     }
 }
@@ -69,22 +69,21 @@ impl WorkerResultExt for TypedTimelineResultWorker {
                 let api = stub_timeline_processor::Api::new(&self.get_worker_info().get_uri());
                 api.get_timeline_result(t1)
             }
-            TypedTimelineResultWorker::LeafTimeline(leaf_node) => {
-                match leaf_node {
-                    LeafTimelineNode::TlHasExisted(worker) => {
-                        let api = stub_event_processor::Api::new(&worker.get_worker_info().get_uri());
-                        api.tl_has_existed_within(t1)
-                    }
-                    LeafTimelineNode::TlHasExistedWithin(worker) => {
-                        let api = stub_event_processor::Api::new(&worker.get_worker_info().get_uri());
-                        api.tl_has_existed_within(t1)
-                    }
-                    LeafTimelineNode::TlLatestEventToState(worker) => {
-                        let api = stub_timeline_processor::Api::new(&worker.get_worker_info().get_uri());
-                        api.get_timeline_result(t1)
-                    }
+            TypedTimelineResultWorker::LeafTimeline(leaf_node) => match leaf_node {
+                LeafTimelineNode::TlHasExisted(worker) => {
+                    let api = stub_event_processor::Api::new(&worker.get_worker_info().get_uri());
+                    api.tl_has_existed_within(t1)
                 }
-            }
+                LeafTimelineNode::TlHasExistedWithin(worker) => {
+                    let api = stub_event_processor::Api::new(&worker.get_worker_info().get_uri());
+                    api.tl_has_existed_within(t1)
+                }
+                LeafTimelineNode::TlLatestEventToState(worker) => {
+                    let api =
+                        stub_timeline_processor::Api::new(&worker.get_worker_info().get_uri());
+                    api.get_timeline_result(t1)
+                }
+            },
         }
     }
 }

--- a/timeline-processor/src/lib.rs
+++ b/timeline-processor/src/lib.rs
@@ -1,43 +1,46 @@
+use crate::bindings::exports::timeline::timeline_processor::api::{
+    DerivedTimelineNode, EventValue, Guest, LeafTimelineNode, TimelineResult, TimelineResultWorker,
+    TypedTimelineResultWorker,
+};
+use crate::bindings::golem::rpc::types::Uri;
+use crate::bindings::timeline::event_processor_stub::stub_event_processor;
+use crate::bindings::timeline::timeline_processor_stub::stub_timeline_processor;
+use conversions::Conversion;
+use extensions::WorkerResultExt;
 use std::cell::RefCell;
 use timeline::event_predicate::EventColumnName;
 use timeline::golem_event::GolemEventValue;
 use timeline::state_dynamic_timeline;
 use timeline::state_dynamic_timeline::StateDynamicsTimeLine;
-use crate::bindings::exports::timeline::timeline_processor::api::{EventValue, Guest, TimelineResult, TypedTimelineResultWorker, DerivedTimelineNode, LeafTimelineNode, TimelineResultWorker};
-use crate::bindings::timeline::event_processor_stub::stub_event_processor;
-use crate::bindings::timeline::timeline_processor_stub::stub_timeline_processor;
-use crate::bindings::golem::rpc::types::Uri;
-use extensions::WorkerResultExt;
-use conversions::Conversion;
 mod bindings;
-mod extensions;
 mod conversions;
+mod extensions;
 
 struct Component;
 
 struct TLEqual {
     child_worker: Option<TypedTimelineResultWorker>,
-    event_value: Option<EventValue>
+    event_value: Option<EventValue>,
 }
 
 struct TLGreaterThan {
     child_worker: Option<TypedTimelineResultWorker>,
-    event_value: Option<EventValue>
+    event_value: Option<EventValue>,
 }
 
 struct TLGreaterThanOrEqualTo {
     child_worker: Option<TypedTimelineResultWorker>,
-    event_value: Option<EventValue>
+    event_value: Option<EventValue>,
 }
 
 struct TLLessThan {
     child_worker: Option<TypedTimelineResultWorker>,
-    event_value: Option<EventValue>
+    event_value: Option<EventValue>,
 }
 
 struct TLLessThanOrEqualTo {
     child_worker: Option<TypedTimelineResultWorker>,
-    event_value: Option<EventValue>
+    event_value: Option<EventValue>,
 }
 
 struct TLAnd {
@@ -53,7 +56,6 @@ struct TLOr {
     child_worker1: Option<TypedTimelineResultWorker>,
     child_worker2: Option<TypedTimelineResultWorker>,
 }
-
 
 thread_local! {
     static ACTIVE_STATE: RefCell<Option<ActiveState>> = RefCell::new(None);
@@ -98,9 +100,7 @@ thread_local! {
     });
 }
 
-fn with_equal_state<T>(
-    f: impl FnOnce(&mut TLEqual) -> Result<T, String>,
-) -> Result<T, String> {
+fn with_equal_state<T>(f: impl FnOnce(&mut TLEqual) -> Result<T, String>) -> Result<T, String> {
     let result = TL_EQUAL_STATE.with_borrow_mut(|state| f(state));
 
     return result;
@@ -138,42 +138,35 @@ fn with_less_than_or_equal_to_state<T>(
     return result;
 }
 
-fn with_and_state<T>(
-    f: impl FnOnce(&mut TLAnd) -> Result<T, String>,
-) -> Result<T, String> {
+fn with_and_state<T>(f: impl FnOnce(&mut TLAnd) -> Result<T, String>) -> Result<T, String> {
     let result = TL_AND_STATE.with_borrow_mut(|state| f(state));
 
     return result;
 }
 
-fn with_or_state<T>(
-    f: impl FnOnce(&mut TLOr) -> Result<T, String>,
-) -> Result<T, String> {
+fn with_or_state<T>(f: impl FnOnce(&mut TLOr) -> Result<T, String>) -> Result<T, String> {
     let result = TL_OR_STATE.with_borrow_mut(|state| f(state));
 
     return result;
 }
 
-fn with_not_state<T>(
-    f: impl FnOnce(&mut TLNot) -> Result<T, String>,
-) -> Result<T, String> {
+fn with_not_state<T>(f: impl FnOnce(&mut TLNot) -> Result<T, String>) -> Result<T, String> {
     let result = TL_NOT_STATE.with_borrow_mut(|state| f(state));
 
     return result;
 }
 
-fn with_active_state<T>(
-    f: impl FnOnce(&mut Option<ActiveState>) -> T,
-) -> T {
+fn with_active_state<T>(f: impl FnOnce(&mut Option<ActiveState>) -> T) -> T {
     let result = ACTIVE_STATE.with_borrow_mut(|state| f(state));
 
     return result;
 }
 
-
-
 impl Guest for Component {
-    fn initialize_equal(child_worker: TypedTimelineResultWorker, event_value: EventValue) -> Result<String, String> {
+    fn initialize_equal(
+        child_worker: TypedTimelineResultWorker,
+        event_value: EventValue,
+    ) -> Result<String, String> {
         with_equal_state(|state| {
             state.child_worker = Some(child_worker);
             state.event_value = Some(event_value);
@@ -187,7 +180,10 @@ impl Guest for Component {
         Ok("Successfully initiated the worker to compute equals".to_string())
     }
 
-    fn initialize_greater_than(child_worker: TypedTimelineResultWorker, event_value: EventValue) -> Result<String, String> {
+    fn initialize_greater_than(
+        child_worker: TypedTimelineResultWorker,
+        event_value: EventValue,
+    ) -> Result<String, String> {
         with_greater_than_state(|state| {
             state.child_worker = Some(child_worker);
             state.event_value = Some(event_value);
@@ -201,7 +197,10 @@ impl Guest for Component {
         Ok("Successfully initiated the worker to compute greater than".to_string())
     }
 
-    fn initialize_greater_than_or_equal_to(child_worker: TypedTimelineResultWorker, event_value: EventValue) -> Result<String, String> {
+    fn initialize_greater_than_or_equal_to(
+        child_worker: TypedTimelineResultWorker,
+        event_value: EventValue,
+    ) -> Result<String, String> {
         with_greater_than_or_equal_to_state(|state| {
             state.child_worker = Some(child_worker);
             state.event_value = Some(event_value);
@@ -215,7 +214,10 @@ impl Guest for Component {
         Ok("Successfully initiated the worker to compute greater than or equal to".to_string())
     }
 
-    fn initialize_less_than(child_worker: TypedTimelineResultWorker, event_value: EventValue) -> Result<String, String> {
+    fn initialize_less_than(
+        child_worker: TypedTimelineResultWorker,
+        event_value: EventValue,
+    ) -> Result<String, String> {
         with_less_than_state(|state| {
             state.child_worker = Some(child_worker);
             state.event_value = Some(event_value);
@@ -229,7 +231,10 @@ impl Guest for Component {
         Ok("Successfully initiated the worker to compute less than".to_string())
     }
 
-    fn initialize_less_than_or_equal_to(child_worker: TypedTimelineResultWorker, event_value: EventValue) -> Result<String, String> {
+    fn initialize_less_than_or_equal_to(
+        child_worker: TypedTimelineResultWorker,
+        event_value: EventValue,
+    ) -> Result<String, String> {
         with_less_than_or_equal_to_state(|state| {
             state.child_worker = Some(child_worker);
             state.event_value = Some(event_value);
@@ -243,7 +248,10 @@ impl Guest for Component {
         Ok("Successfully initiated the worker to compute less than or equal to".to_string())
     }
 
-    fn initialize_and(child_worker1: TypedTimelineResultWorker, child_worker2: TypedTimelineResultWorker) -> Result<String, String> {
+    fn initialize_and(
+        child_worker1: TypedTimelineResultWorker,
+        child_worker2: TypedTimelineResultWorker,
+    ) -> Result<String, String> {
         with_and_state(|state| {
             state.child_worker1 = Some(child_worker1);
             state.child_worker2 = Some(child_worker2);
@@ -257,7 +265,10 @@ impl Guest for Component {
         Ok("Successfully initiated the worker to compute and".to_string())
     }
 
-    fn initialize_or(child_worker1: TypedTimelineResultWorker, child_worker2: TypedTimelineResultWorker) -> Result<String, String> {
+    fn initialize_or(
+        child_worker1: TypedTimelineResultWorker,
+        child_worker2: TypedTimelineResultWorker,
+    ) -> Result<String, String> {
         with_or_state(|state| {
             state.child_worker1 = Some(child_worker1);
             state.child_worker2 = Some(child_worker2);
@@ -285,122 +296,134 @@ impl Guest for Component {
     }
 
     fn get_timeline_result(t1: u64) -> Result<TimelineResult, String> {
-        with_active_state(|state| {
-            match state {
-                Some(ActiveState::Equal) => {
-                    with_equal_state(|state| {
-                        let child_worker = state.child_worker.as_ref().unwrap();
-                        let event_value = state.event_value.as_ref().unwrap();
-                        let golem_event_value = GolemEventValue::from_wit(event_value.clone());
-                        let time_line_result = child_worker.get_timeline_result(t1)?;
-                        let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
-                        let result = state_dynamic_timeline.equal_to(golem_event_value).map(|x| GolemEventValue::BoolValue(*x));
+        with_active_state(|state| match state {
+            Some(ActiveState::Equal) => with_equal_state(|state| {
+                let child_worker = state.child_worker.as_ref().unwrap();
+                let event_value = state.event_value.as_ref().unwrap();
+                let golem_event_value = GolemEventValue::from_wit(event_value.clone());
+                let time_line_result = child_worker.get_timeline_result(t1)?;
+                let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
+                let result = state_dynamic_timeline
+                    .equal_to(golem_event_value)
+                    .map(|x| GolemEventValue::BoolValue(*x));
 
-                        Ok(result.to_wit())
-                    })
-                }
-                Some(ActiveState::GreaterThan) => {
-                    with_greater_than_state(|state| {
-                        let child_worker = state.child_worker.as_ref().unwrap();
-                        let event_value = state.event_value.as_ref().unwrap();
-                        let golem_event_value = GolemEventValue::from_wit(event_value.clone());
-                        let time_line_result = child_worker.get_timeline_result(t1)?;
-                        let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
-                        let result = state_dynamic_timeline.greater_than(golem_event_value).map(|x| GolemEventValue::BoolValue(*x));
+                Ok(result.to_wit())
+            }),
+            Some(ActiveState::GreaterThan) => with_greater_than_state(|state| {
+                let child_worker = state.child_worker.as_ref().unwrap();
+                let event_value = state.event_value.as_ref().unwrap();
+                let golem_event_value = GolemEventValue::from_wit(event_value.clone());
+                let time_line_result = child_worker.get_timeline_result(t1)?;
+                let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
+                let result = state_dynamic_timeline
+                    .greater_than(golem_event_value)
+                    .map(|x| GolemEventValue::BoolValue(*x));
 
-                        Ok(result.to_wit())
-                    })
-                }
-                Some(ActiveState::GreaterThanOrEqualTo) => {
-                    with_greater_than_or_equal_to_state(|state| {
-                        let child_worker = state.child_worker.as_ref().unwrap();
-                        let event_value = state.event_value.as_ref().unwrap();
-                        let golem_event_value = GolemEventValue::from_wit(event_value.clone());
-                        let time_line_result = child_worker.get_timeline_result(t1)?;
-                        let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
-                        let result = state_dynamic_timeline.greater_than_or_equal_to(golem_event_value).map(|x| GolemEventValue::BoolValue(*x));
+                Ok(result.to_wit())
+            }),
+            Some(ActiveState::GreaterThanOrEqualTo) => {
+                with_greater_than_or_equal_to_state(|state| {
+                    let child_worker = state.child_worker.as_ref().unwrap();
+                    let event_value = state.event_value.as_ref().unwrap();
+                    let golem_event_value = GolemEventValue::from_wit(event_value.clone());
+                    let time_line_result = child_worker.get_timeline_result(t1)?;
+                    let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
+                    let result = state_dynamic_timeline
+                        .greater_than_or_equal_to(golem_event_value)
+                        .map(|x| GolemEventValue::BoolValue(*x));
 
-                        Ok(result.to_wit())
-                    })
-                }
-
-                Some(ActiveState::LessThan) => {
-                    with_less_than_state(|state| {
-                        let child_worker = state.child_worker.as_ref().unwrap();
-                        let event_value = state.event_value.as_ref().unwrap();
-                        let golem_event_value = GolemEventValue::from_wit(event_value.clone());
-                        let time_line_result = child_worker.get_timeline_result(t1)?;
-                        let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
-                        let result = state_dynamic_timeline.less_than(golem_event_value).map(|x| GolemEventValue::BoolValue(*x));
-
-                        Ok(result.to_wit())
-                    })
-                }
-
-                Some(ActiveState::LessThanOrEqualTo) => {
-                    with_less_than_or_equal_to_state(|state| {
-                        let child_worker = state.child_worker.as_ref().unwrap();
-                        let event_value = state.event_value.as_ref().unwrap();
-                        let golem_event_value = GolemEventValue::from_wit(event_value.clone());
-                        let time_line_result = child_worker.get_timeline_result(t1)?;
-                        let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
-                        let result = state_dynamic_timeline.less_than_or_equal_to(golem_event_value).map(|x| GolemEventValue::BoolValue(*x));
-
-                        Ok(result.to_wit())
-                    })
-                }
-
-                Some(ActiveState::And) => {
-                    with_and_state(|state| {
-                        let child_worker1 = state.child_worker1.as_ref().unwrap();
-                        let child_worker2 = state.child_worker2.as_ref().unwrap();
-                        let time_line_result1 = child_worker1.get_timeline_result(t1)?;
-                        let time_line_result2 = child_worker2.get_timeline_result(t1)?;
-                        let state_dynamic_timeline1 =
-                            StateDynamicsTimeLine::from_wit(time_line_result1)
-                                .map_fallible(|x| x.get_bool().ok_or("Timeline is not a boolean timeline to apply AND logic".to_string()))?;
-                        let state_dynamic_timeline2 =
-                            StateDynamicsTimeLine::from_wit(time_line_result2)
-                                .map_fallible(|x| x.get_bool().ok_or("Timeline is not a boolean timeline to apply AND logic".to_string()))?;
-                        let result = state_dynamic_timeline1.and(state_dynamic_timeline2).map(|x| GolemEventValue::BoolValue(*x));
-
-                        Ok(result.to_wit())
-                    })
-                }
-
-                Some(ActiveState::Or) => {
-                    with_or_state(|state| {
-                        let child_worker1 = state.child_worker1.as_ref().unwrap();
-                        let child_worker2 = state.child_worker2.as_ref().unwrap();
-                        let time_line_result1 = child_worker1.get_timeline_result(t1)?;
-                        let time_line_result2 = child_worker2.get_timeline_result(t1)?;
-                        let state_dynamic_timeline1 =
-                            StateDynamicsTimeLine::from_wit(time_line_result1)
-                                .map_fallible(|x| x.get_bool().ok_or("Timeline is not a boolean timeline to apply OR logic".to_string()))?;
-                        let state_dynamic_timeline2 =
-                            StateDynamicsTimeLine::from_wit(time_line_result2)
-                                .map_fallible(|x| x.get_bool().ok_or("Timeline is not a boolean timeline to apply OR logic".to_string()))?;
-                        let result = state_dynamic_timeline1.or(state_dynamic_timeline2).map(|x| GolemEventValue::BoolValue(*x));
-
-                        Ok(result.to_wit())
-                    })
-                }
-
-                Some(ActiveState::Not) => {
-                    with_not_state(|state| {
-                        let child_worker = state.child_worker.as_ref().unwrap();
-                        let time_line_result = child_worker.get_timeline_result(t1)?;
-                        let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
-                        let result = state_dynamic_timeline.map_fallible(|x| x.get_bool().map(|bool | GolemEventValue::BoolValue(!bool)).ok_or("Timeline is not a boolean timeline to apply NOT logic".to_string()))?;
-
-                        Ok(result.to_wit())
-                    })
-                }
-
-                None => {
-                    Err("No active state to compute in derived timeline workers".to_string())
-                }
+                    Ok(result.to_wit())
+                })
             }
+
+            Some(ActiveState::LessThan) => with_less_than_state(|state| {
+                let child_worker = state.child_worker.as_ref().unwrap();
+                let event_value = state.event_value.as_ref().unwrap();
+                let golem_event_value = GolemEventValue::from_wit(event_value.clone());
+                let time_line_result = child_worker.get_timeline_result(t1)?;
+                let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
+                let result = state_dynamic_timeline
+                    .less_than(golem_event_value)
+                    .map(|x| GolemEventValue::BoolValue(*x));
+
+                Ok(result.to_wit())
+            }),
+
+            Some(ActiveState::LessThanOrEqualTo) => with_less_than_or_equal_to_state(|state| {
+                let child_worker = state.child_worker.as_ref().unwrap();
+                let event_value = state.event_value.as_ref().unwrap();
+                let golem_event_value = GolemEventValue::from_wit(event_value.clone());
+                let time_line_result = child_worker.get_timeline_result(t1)?;
+                let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
+                let result = state_dynamic_timeline
+                    .less_than_or_equal_to(golem_event_value)
+                    .map(|x| GolemEventValue::BoolValue(*x));
+
+                Ok(result.to_wit())
+            }),
+
+            Some(ActiveState::And) => with_and_state(|state| {
+                let child_worker1 = state.child_worker1.as_ref().unwrap();
+                let child_worker2 = state.child_worker2.as_ref().unwrap();
+                let time_line_result1 = child_worker1.get_timeline_result(t1)?;
+                let time_line_result2 = child_worker2.get_timeline_result(t1)?;
+                let state_dynamic_timeline1 = StateDynamicsTimeLine::from_wit(time_line_result1)
+                    .map_fallible(|x| {
+                        x.get_bool().ok_or(
+                            "Timeline is not a boolean timeline to apply AND logic".to_string(),
+                        )
+                    })?;
+                let state_dynamic_timeline2 = StateDynamicsTimeLine::from_wit(time_line_result2)
+                    .map_fallible(|x| {
+                        x.get_bool().ok_or(
+                            "Timeline is not a boolean timeline to apply AND logic".to_string(),
+                        )
+                    })?;
+                let result = state_dynamic_timeline1
+                    .and(state_dynamic_timeline2)
+                    .map(|x| GolemEventValue::BoolValue(*x));
+
+                Ok(result.to_wit())
+            }),
+
+            Some(ActiveState::Or) => with_or_state(|state| {
+                let child_worker1 = state.child_worker1.as_ref().unwrap();
+                let child_worker2 = state.child_worker2.as_ref().unwrap();
+                let time_line_result1 = child_worker1.get_timeline_result(t1)?;
+                let time_line_result2 = child_worker2.get_timeline_result(t1)?;
+                let state_dynamic_timeline1 = StateDynamicsTimeLine::from_wit(time_line_result1)
+                    .map_fallible(|x| {
+                        x.get_bool().ok_or(
+                            "Timeline is not a boolean timeline to apply OR logic".to_string(),
+                        )
+                    })?;
+                let state_dynamic_timeline2 = StateDynamicsTimeLine::from_wit(time_line_result2)
+                    .map_fallible(|x| {
+                        x.get_bool().ok_or(
+                            "Timeline is not a boolean timeline to apply OR logic".to_string(),
+                        )
+                    })?;
+                let result = state_dynamic_timeline1
+                    .or(state_dynamic_timeline2)
+                    .map(|x| GolemEventValue::BoolValue(*x));
+
+                Ok(result.to_wit())
+            }),
+
+            Some(ActiveState::Not) => with_not_state(|state| {
+                let child_worker = state.child_worker.as_ref().unwrap();
+                let time_line_result = child_worker.get_timeline_result(t1)?;
+                let state_dynamic_timeline = StateDynamicsTimeLine::from_wit(time_line_result);
+                let result = state_dynamic_timeline.map_fallible(|x| {
+                    x.get_bool()
+                        .map(|bool| GolemEventValue::BoolValue(!bool))
+                        .ok_or("Timeline is not a boolean timeline to apply NOT logic".to_string())
+                })?;
+
+                Ok(result.to_wit())
+            }),
+
+            None => Err("No active state to compute in derived timeline workers".to_string()),
         })
     }
 }

--- a/timeline/src/event_predicate.rs
+++ b/timeline/src/event_predicate.rs
@@ -88,20 +88,17 @@ impl Display for GolemEventPredicate<GolemEventValue> {
 impl<T: PartialEq + PartialOrd + Clone + Debug> GolemEventPredicate<T> {
     pub fn evaluate(&self, event: &GolemEvent<T>) -> bool {
         match self {
-            GolemEventPredicate::Equals(event_column_name, event_value) => event
-                .event
-                .get(event_column_name)
-                .map_or(false, |v| v == &event_value.0),
+            GolemEventPredicate::Equals(event_column_name, event_value) => {
+                event.event.get(event_column_name).map_or(false, |v| v == &event_value.0)
+            }
 
-            GolemEventPredicate::GreaterThan(event_column_name, event_value) => event
-                .event
-                .get(event_column_name)
-                .map_or(false, |v| v > &event_value.0),
+            GolemEventPredicate::GreaterThan(event_column_name, event_value) => {
+                event.event.get(event_column_name).map_or(false, |v| v > &event_value.0)
+            }
 
-            GolemEventPredicate::LessThan(event_column_name, event_value) => event
-                .event
-                .get(event_column_name)
-                .map_or(false, |v| v < &event_value.0),
+            GolemEventPredicate::LessThan(event_column_name, event_value) => {
+                event.event.get(event_column_name).map_or(false, |v| v < &event_value.0)
+            }
             GolemEventPredicate::And(left, right) => left.evaluate(event) && right.evaluate(event),
             GolemEventPredicate::Or(left, right) => left.evaluate(event) || right.evaluate(event),
         }

--- a/timeline/src/internals/aligned_state_dynamic_timeline.rs
+++ b/timeline/src/internals/aligned_state_dynamic_timeline.rs
@@ -30,9 +30,8 @@ impl<T: Clone + Debug + PartialEq + PartialOrd> AlignedStateDynamicsTimeLine<T> 
         if &left.beginning() <= &right.beginning() {
             let boundary = right.beginning().map_or(None, |t| left.boundary(t));
 
-            let new_points = boundary.map_or(left.points.clone(), |boundary| {
-                left.points.split_off(&boundary)
-            });
+            let new_points =
+                boundary.map_or(left.points.clone(), |boundary| left.points.split_off(&boundary));
 
             AlignedStateDynamicsTimeLine {
                 time_line1: StateDynamicsTimeLine { points: new_points },
@@ -45,9 +44,8 @@ impl<T: Clone + Debug + PartialEq + PartialOrd> AlignedStateDynamicsTimeLine<T> 
         } else {
             let boundary = left.beginning().map_or(None, |t| right.boundary(t));
 
-            let new_points = boundary.map_or(right.points.clone(), |boundary| {
-                right.points.split_off(&boundary)
-            });
+            let new_points =
+                boundary.map_or(right.points.clone(), |boundary| right.points.split_off(&boundary));
 
             AlignedStateDynamicsTimeLine {
                 time_line1: left.clone(),

--- a/timeline/src/internals/boundaries.rs
+++ b/timeline/src/internals/boundaries.rs
@@ -85,10 +85,6 @@ impl<'t, T: Debug + Clone> Boundaries<'t, T> {
             }
         };
 
-        Boundaries {
-            left: left_boundary,
-            intersection,
-            right: right_boundary,
-        }
+        Boundaries { left: left_boundary, intersection, right: right_boundary }
     }
 }

--- a/timeline/src/state_dynamic_timeline.rs
+++ b/timeline/src/state_dynamic_timeline.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
-
 use crate::event_timeline::EventTimeLine;
 use crate::internals::aligned_state_dynamic_timeline::AlignedStateDynamicsTimeLine;
 use crate::internals::boundaries::Boundaries;
@@ -14,27 +13,23 @@ pub struct StateDynamicsTimeLine<T> {
 }
 
 impl<T: Clone + PartialEq> StateDynamicsTimeLine<T> {
-
     pub fn map<B>(&self, f: impl Fn(&T) -> B) -> StateDynamicsTimeLine<B> {
         let mut new_points = BTreeMap::new();
         for (k, v) in &self.points {
-            new_points.insert(*k, StateDynamicsTimeLinePoint {
-                t1: v.t1,
-                t2: v.t2,
-                value: f(&v.value),
-            });
+            new_points
+                .insert(*k, StateDynamicsTimeLinePoint { t1: v.t1, t2: v.t2, value: f(&v.value) });
         }
         StateDynamicsTimeLine { points: new_points }
     }
 
-    pub fn map_fallible<B>(&self, f: impl Fn(&T) -> Result<B, String>) -> Result<StateDynamicsTimeLine<B>, String> {
+    pub fn map_fallible<B>(
+        &self,
+        f: impl Fn(&T) -> Result<B, String>,
+    ) -> Result<StateDynamicsTimeLine<B>, String> {
         let mut new_points = BTreeMap::new();
         for (k, v) in &self.points {
-            new_points.insert(*k, StateDynamicsTimeLinePoint {
-                t1: v.t1,
-                t2: v.t2,
-                value: f(&v.value)?,
-            });
+            new_points
+                .insert(*k, StateDynamicsTimeLinePoint { t1: v.t1, t2: v.t2, value: f(&v.value)? });
         }
         Ok(StateDynamicsTimeLine { points: new_points })
     }
@@ -56,9 +51,7 @@ impl<T: Clone + PartialEq> StateDynamicsTimeLine<T> {
     }
 
     pub fn future_is(&self, value: T) -> bool {
-        self.last()
-            .map(|x| x.t2.is_none() && x.value == value)
-            .unwrap_or(false)
+        self.last().map(|x| x.t2.is_none() && x.value == value).unwrap_or(false)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -113,11 +106,7 @@ impl<T: Clone + PartialEq> StateDynamicsTimeLine<T> {
                         value: left.value.clone(),
                     };
 
-                    let new_point = StateDynamicsTimeLinePoint {
-                        t1: r,
-                        t2: left.t2,
-                        value,
-                    };
+                    let new_point = StateDynamicsTimeLinePoint { t1: r, t2: left.t2, value };
 
                     self.points.insert(l.clone(), updated_left);
                     self.points.insert(r, new_point);
@@ -153,11 +142,8 @@ impl<T: Clone + PartialEq> StateDynamicsTimeLine<T> {
                                 value: left.value.clone(),
                             };
 
-                            let new_point = StateDynamicsTimeLinePoint {
-                                t1: r,
-                                t2: left.t2,
-                                value,
-                            };
+                            let new_point =
+                                StateDynamicsTimeLinePoint { t1: r, t2: left.t2, value };
 
                             self.points.insert(l.clone(), updated_left);
                             self.points.insert(r, new_point);
@@ -168,11 +154,8 @@ impl<T: Clone + PartialEq> StateDynamicsTimeLine<T> {
                                 value: left.value.clone(),
                             };
 
-                            let new_point = StateDynamicsTimeLinePoint {
-                                t1: new_time,
-                                t2: None,
-                                value,
-                            };
+                            let new_point =
+                                StateDynamicsTimeLinePoint { t1: new_time, t2: None, value };
 
                             self.points.insert(left.t1, updated_left);
                             self.points.insert(new_time, new_point);
@@ -194,11 +177,8 @@ impl<T: Clone + PartialEq> StateDynamicsTimeLine<T> {
                     self.points.remove_entry(&right.t1);
                     self.points.insert(new_time, updated_right);
                 } else {
-                    let new_point = StateDynamicsTimeLinePoint {
-                        t1: new_time,
-                        t2: Some(right.t1),
-                        value,
-                    };
+                    let new_point =
+                        StateDynamicsTimeLinePoint { t1: new_time, t2: Some(right.t1), value };
                     self.points.insert(new_time, new_point);
                 }
             }
@@ -207,11 +187,7 @@ impl<T: Clone + PartialEq> StateDynamicsTimeLine<T> {
             (None, None) => {
                 let l = new_time;
                 let r = None;
-                let new_point = StateDynamicsTimeLinePoint {
-                    t1: l,
-                    t2: r,
-                    value,
-                };
+                let new_point = StateDynamicsTimeLinePoint { t1: l, t2: r, value };
                 self.points.insert(l, new_point);
             }
         }
@@ -220,9 +196,7 @@ impl<T: Clone + PartialEq> StateDynamicsTimeLine<T> {
 
 impl<T> Default for StateDynamicsTimeLine<T> {
     fn default() -> Self {
-        StateDynamicsTimeLine {
-            points: BTreeMap::new(),
-        }
+        StateDynamicsTimeLine { points: BTreeMap::new() }
     }
 }
 
@@ -370,7 +344,8 @@ impl<T: Debug + Clone + PartialOrd> StateDynamicsTimeLine<T> {
 
         for point in &self.points {
             let is_greater_than_or_equal = point.1.value >= constant;
-            state_dynamics_time_line.add_state_dynamic_info(point.0.clone(), is_greater_than_or_equal);
+            state_dynamics_time_line
+                .add_state_dynamic_info(point.0.clone(), is_greater_than_or_equal);
         }
 
         state_dynamics_time_line
@@ -430,11 +405,8 @@ impl<T: Debug + Clone + PartialOrd> StateDynamicsTimeLine<T> {
             let self_point = self_iter.next().unwrap();
             let other_point = other_iter.next().unwrap();
 
-            let Boundaries {
-                left: left_ex,
-                intersection,
-                right: right_ex,
-            } = Boundaries::get_boundaries(self_point.1, other_point.1);
+            let Boundaries { left: left_ex, intersection, right: right_ex } =
+                Boundaries::get_boundaries(self_point.1, other_point.1);
 
             flattened_time_line_points.insert(intersection.t1, intersection.apply_f(&f));
 
@@ -473,19 +445,17 @@ impl<T: Debug + Clone + PartialOrd> StateDynamicsTimeLine<T> {
             }
         }
 
-        StateDynamicsTimeLine {
-            points: flattened_time_line_points,
-        }
+        StateDynamicsTimeLine { points: flattened_time_line_points }
     }
 }
 
 // ~~ represents `forever`
 // -- denotes a finite boundary
 mod tests {
-    use std::collections::BTreeMap;
     use crate::event_timeline::{EventTimeLine, EventTimeLinePoint};
     use crate::state_dynamic_timeline::StateDynamicsTimeLine;
     use crate::state_dynamic_timeline_point::StateDynamicsTimeLinePoint;
+    use std::collections::BTreeMap;
 
     // t1~~~~(playing)~~~~~~~~~~~~>
     //       t2~~~~(movie)~~~~~~~~~~>
@@ -507,20 +477,12 @@ mod tests {
         let mut btree_map1 = BTreeMap::new();
         btree_map1.insert(
             5,
-            StateDynamicsTimeLinePoint {
-                t1: 5,
-                t2: Some(7),
-                value: "playing".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 5, t2: Some(7), value: "playing".to_string() },
         );
 
         btree_map1.insert(
             7,
-            StateDynamicsTimeLinePoint {
-                t1: 7,
-                t2: None,
-                value: "playing movie".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 7, t2: None, value: "playing movie".to_string() },
         );
 
         let expected1 = StateDynamicsTimeLine { points: btree_map1 };
@@ -529,20 +491,12 @@ mod tests {
 
         btree_map2.insert(
             5,
-            StateDynamicsTimeLinePoint {
-                t1: 5,
-                t2: Some(7),
-                value: "playing".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 5, t2: Some(7), value: "playing".to_string() },
         );
 
         btree_map2.insert(
             7,
-            StateDynamicsTimeLinePoint {
-                t1: 7,
-                t2: None,
-                value: "movie playing".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 7, t2: None, value: "movie playing".to_string() },
         );
 
         let expected2 = StateDynamicsTimeLine { points: btree_map2 };
@@ -574,38 +528,22 @@ mod tests {
 
         btree_map.insert(
             5,
-            StateDynamicsTimeLinePoint {
-                t1: 5,
-                t2: Some(7),
-                value: "playing".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 5, t2: Some(7), value: "playing".to_string() },
         );
 
         btree_map.insert(
             7,
-            StateDynamicsTimeLinePoint {
-                t1: 7,
-                t2: Some(8),
-                value: "movie playing".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 7, t2: Some(8), value: "movie playing".to_string() },
         );
 
         btree_map.insert(
             8,
-            StateDynamicsTimeLinePoint {
-                t1: 8,
-                t2: Some(9),
-                value: "movie pause".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 8, t2: Some(9), value: "movie pause".to_string() },
         );
 
         btree_map.insert(
             9,
-            StateDynamicsTimeLinePoint {
-                t1: 9,
-                t2: None,
-                value: "cartoon pause".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 9, t2: None, value: "cartoon pause".to_string() },
         );
 
         let expected = StateDynamicsTimeLine { points: btree_map };
@@ -636,38 +574,22 @@ mod tests {
 
         btree_map.insert(
             1,
-            StateDynamicsTimeLinePoint {
-                t1: 1,
-                t2: Some(2),
-                value: "playing".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 1, t2: Some(2), value: "playing".to_string() },
         );
 
         btree_map.insert(
             2,
-            StateDynamicsTimeLinePoint {
-                t1: 2,
-                t2: Some(3),
-                value: "movie playing".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 2, t2: Some(3), value: "movie playing".to_string() },
         );
 
         btree_map.insert(
             3,
-            StateDynamicsTimeLinePoint {
-                t1: 3,
-                t2: Some(4),
-                value: "cartoon playing".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 3, t2: Some(4), value: "cartoon playing".to_string() },
         );
 
         btree_map.insert(
             4,
-            StateDynamicsTimeLinePoint {
-                t1: 4,
-                t2: None,
-                value: "cartoon pause".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 4, t2: None, value: "cartoon pause".to_string() },
         );
 
         let expected = StateDynamicsTimeLine { points: btree_map };
@@ -696,29 +618,17 @@ mod tests {
 
         btree_map.insert(
             1,
-            StateDynamicsTimeLinePoint {
-                t1: 1,
-                t2: Some(2),
-                value: "pause".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 1, t2: Some(2), value: "pause".to_string() },
         );
 
         btree_map.insert(
             2,
-            StateDynamicsTimeLinePoint {
-                t1: 2,
-                t2: Some(3),
-                value: "playing".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 2, t2: Some(3), value: "playing".to_string() },
         );
 
         btree_map.insert(
             3,
-            StateDynamicsTimeLinePoint {
-                t1: 3,
-                t2: None,
-                value: "playing movie".to_string(),
-            },
+            StateDynamicsTimeLinePoint { t1: 3, t2: None, value: "playing movie".to_string() },
         );
 
         let expected = StateDynamicsTimeLine { points: btree_map };
@@ -835,32 +745,11 @@ mod tests {
 
         let mut btree_map = BTreeMap::new();
 
-        btree_map.insert(
-            1,
-            StateDynamicsTimeLinePoint {
-                t1: 1,
-                t2: Some(2),
-                value: false,
-            },
-        );
+        btree_map.insert(1, StateDynamicsTimeLinePoint { t1: 1, t2: Some(2), value: false });
 
-        btree_map.insert(
-            2,
-            StateDynamicsTimeLinePoint {
-                t1: 2,
-                t2: Some(3),
-                value: true,
-            },
-        );
+        btree_map.insert(2, StateDynamicsTimeLinePoint { t1: 2, t2: Some(3), value: true });
 
-        btree_map.insert(
-            3,
-            StateDynamicsTimeLinePoint {
-                t1: 3,
-                t2: None,
-                value: false,
-            },
-        );
+        btree_map.insert(3, StateDynamicsTimeLinePoint { t1: 3, t2: None, value: false });
 
         let expected = StateDynamicsTimeLine { points: btree_map };
 

--- a/timeline/src/state_dynamic_timeline_point.rs
+++ b/timeline/src/state_dynamic_timeline_point.rs
@@ -18,16 +18,11 @@ impl<T: Clone> StateDynamicsTimeLinePoint<T> {
     }
 }
 
-
 impl<'t, T: Clone> StateDynamicsTimeLinePoint<ZipResult<'t, T>> {
     pub fn apply_f<F>(&self, f: &F) -> StateDynamicsTimeLinePoint<T>
     where
         F: Fn(&T, &T) -> T,
     {
-        StateDynamicsTimeLinePoint {
-            t1: self.t1,
-            t2: self.t2,
-            value: self.value.merge(&f),
-        }
+        StateDynamicsTimeLinePoint { t1: self.t1, t2: self.t2, value: self.value.merge(&f) }
     }
 }

--- a/timeline/src/timeline_node_worker.rs
+++ b/timeline/src/timeline_node_worker.rs
@@ -119,17 +119,11 @@ impl TypedTimeLineResultWorker {
 
 #[derive(Clone, Debug, Serialize)]
 pub enum LeafTimeLineNode {
-    TLHasExisted {
-        time_line_worker: TimeLineResultWorker,
-    },
+    TLHasExisted { time_line_worker: TimeLineResultWorker },
 
-    TLHasExistedWithin {
-        time_line_worker: TimeLineResultWorker,
-    },
+    TLHasExistedWithin { time_line_worker: TimeLineResultWorker },
 
-    TLEventToLatestState {
-        time_line_worker: TimeLineResultWorker,
-    },
+    TLEventToLatestState { time_line_worker: TimeLineResultWorker },
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/timeline/src/timeline_op.rs
+++ b/timeline/src/timeline_op.rs
@@ -39,11 +39,7 @@ pub enum TimeLineOp {
     // t3-t7: true
     // t7-t9: false
     // t9-t13: true
-    TlHasExistedWithin(
-        TimeLineNodeWorkerInput,
-        GolemEventPredicate<GolemEventValue>,
-        u64,
-    ),
+    TlHasExistedWithin(TimeLineNodeWorkerInput, GolemEventPredicate<GolemEventValue>, u64),
     // This is more or less making number of events to a very simple
     // timeline. Obviously this is corresponding to the events that are state dynamic in nature
     // t1 - t10 : CDN2
@@ -162,20 +158,12 @@ impl Display for TimeLineOp {
         }
 
         match self {
-            TimeLineOp::EqualTo(server, time_line, golem_event_value) => write!(
-                f,
-                "EqualTo({}, {}, {})",
-                server,
-                time_line,
-                text_of(golem_event_value)
-            ),
-            TimeLineOp::GreaterThan(server, time_line, golem_event_value) => write!(
-                f,
-                "GreaterThan({}, {}, {})",
-                server,
-                time_line,
-                text_of(golem_event_value)
-            ),
+            TimeLineOp::EqualTo(server, time_line, golem_event_value) => {
+                write!(f, "EqualTo({}, {}, {})", server, time_line, text_of(golem_event_value))
+            }
+            TimeLineOp::GreaterThan(server, time_line, golem_event_value) => {
+                write!(f, "GreaterThan({}, {}, {})", server, time_line, text_of(golem_event_value))
+            }
             TimeLineOp::GreaterThanOrEqual(server, time_line, golem_event_value) => write!(
                 f,
                 "GreaterThanOrEqual({}, {}, {})",
@@ -183,13 +171,9 @@ impl Display for TimeLineOp {
                 time_line,
                 text_of(golem_event_value)
             ),
-            TimeLineOp::LessThan(server, time_line, golem_event_value) => write!(
-                f,
-                "LessThan({}, {}, {})",
-                server,
-                time_line,
-                text_of(golem_event_value)
-            ),
+            TimeLineOp::LessThan(server, time_line, golem_event_value) => {
+                write!(f, "LessThan({}, {}, {})", server, time_line, text_of(golem_event_value))
+            }
             TimeLineOp::LessThanOrEqual(server, time_line, golem_event_value) => write!(
                 f,
                 "LessThanOrEqual({}, {}, {})",
@@ -207,11 +191,9 @@ impl Display for TimeLineOp {
             TimeLineOp::TlHasExisted(server, event_predicate) => {
                 write!(f, "TlHasExisted({}, {})", server, event_predicate)
             }
-            TimeLineOp::TlHasExistedWithin(server, event_predicate, within_time) => write!(
-                f,
-                "TlHasExistedWithin({}, {}, {})",
-                server, event_predicate, within_time
-            ),
+            TimeLineOp::TlHasExistedWithin(server, event_predicate, within_time) => {
+                write!(f, "TlHasExistedWithin({}, {}, {})", server, event_predicate, within_time)
+            }
             TimeLineOp::TlLatestEventToState(server, event_column) => {
                 write!(f, "TlLatestEventToState({}, {})", server, event_column)
             }


### PR DESCRIPTION
Used default rust-analyzer formatting rules,  as it is most widely used and hence should also be good enough for us, see https://github.com/rust-lang/rust-analyzer/blob/master/rustfmt.toml.

Added documentation instructing RustRover/IntelliJ users to use rustfmt instead of default formatter