### PR TITLE
Work with timelinedsl directly

### DIFF
--- a/core-stub/Cargo.toml
+++ b/core-stub/Cargo.toml
@@ -10,23 +10,23 @@ package = "timeline:core"
 world = "wasm-rpc-stub-core"
 path = "wit"
 
-[package.metadata.component.target.dependencies."timeline:core"]
-path = "wit/deps/timeline_core"
-
-[package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
-path = "wit/deps/timeline_timeline-processor-stub"
-
-[package.metadata.component.target.dependencies."timeline:event-processor-stub"]
-path = "wit/deps/timeline_event-processor-stub"
+[package.metadata.component.target.dependencies."timeline:event-processor"]
+path = "wit/deps/timeline_event-processor"
 
 [package.metadata.component.target.dependencies."golem:rpc"]
 path = "wit/deps/wasm-rpc"
 
-[package.metadata.component.target.dependencies."timeline:event-processor"]
-path = "wit/deps/timeline_event-processor"
+[package.metadata.component.target.dependencies."timeline:core"]
+path = "wit/deps/timeline_core"
 
 [package.metadata.component.target.dependencies."timeline:timeline-processor"]
 path = "wit/deps/timeline_timeline-processor"
+
+[package.metadata.component.target.dependencies."timeline:event-processor-stub"]
+path = "wit/deps/timeline_event-processor-stub"
+
+[package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
+path = "wit/deps/timeline_timeline-processor-stub"
 
 [dependencies.golem-wasm-rpc]
 version = "0.0.22"

--- a/core-stub/Cargo.toml
+++ b/core-stub/Cargo.toml
@@ -10,23 +10,23 @@ package = "timeline:core"
 world = "wasm-rpc-stub-core"
 path = "wit"
 
-[package.metadata.component.target.dependencies."timeline:event-processor"]
-path = "wit/deps/timeline_event-processor"
-
-[package.metadata.component.target.dependencies."golem:rpc"]
-path = "wit/deps/wasm-rpc"
-
-[package.metadata.component.target.dependencies."timeline:core"]
-path = "wit/deps/timeline_core"
-
-[package.metadata.component.target.dependencies."timeline:timeline-processor"]
-path = "wit/deps/timeline_timeline-processor"
-
 [package.metadata.component.target.dependencies."timeline:event-processor-stub"]
 path = "wit/deps/timeline_event-processor-stub"
 
 [package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
 path = "wit/deps/timeline_timeline-processor-stub"
+
+[package.metadata.component.target.dependencies."timeline:event-processor"]
+path = "wit/deps/timeline_event-processor"
+
+[package.metadata.component.target.dependencies."timeline:timeline-processor"]
+path = "wit/deps/timeline_timeline-processor"
+
+[package.metadata.component.target.dependencies."timeline:core"]
+path = "wit/deps/timeline_core"
+
+[package.metadata.component.target.dependencies."golem:rpc"]
+path = "wit/deps/wasm-rpc"
 
 [dependencies.golem-wasm-rpc]
 version = "0.0.22"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,20 +7,20 @@ version = "0.1.0"
 world = "core"
 path = "wit"
 
+[package.metadata.component.target.dependencies."timeline:event-processor-stub"]
+path = "wit/deps/timeline_event-processor-stub"
+
+[package.metadata.component.target.dependencies."timeline:event-processor"]
+path = "wit/deps/timeline_event-processor"
+
 [package.metadata.component.target.dependencies."timeline:timeline-processor"]
 path = "wit/deps/timeline_timeline-processor"
 
 [package.metadata.component.target.dependencies."golem:rpc"]
 path = "wit/deps/wasm-rpc"
 
-[package.metadata.component.target.dependencies."timeline:event-processor-stub"]
-path = "wit/deps/timeline_event-processor-stub"
-
 [package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
 path = "wit/deps/timeline_timeline-processor-stub"
-
-[package.metadata.component.target.dependencies."timeline:event-processor"]
-path = "wit/deps/timeline_event-processor"
 
 [dependencies]
 bitflags = "2.4.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,17 +7,17 @@ version = "0.1.0"
 world = "core"
 path = "wit"
 
-[package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
-path = "wit/deps/timeline_timeline-processor-stub"
-
-[package.metadata.component.target.dependencies."timeline:event-processor-stub"]
-path = "wit/deps/timeline_event-processor-stub"
+[package.metadata.component.target.dependencies."timeline:timeline-processor"]
+path = "wit/deps/timeline_timeline-processor"
 
 [package.metadata.component.target.dependencies."golem:rpc"]
 path = "wit/deps/wasm-rpc"
 
-[package.metadata.component.target.dependencies."timeline:timeline-processor"]
-path = "wit/deps/timeline_timeline-processor"
+[package.metadata.component.target.dependencies."timeline:event-processor-stub"]
+path = "wit/deps/timeline_event-processor-stub"
+
+[package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
+path = "wit/deps/timeline_timeline-processor-stub"
 
 [package.metadata.component.target.dependencies."timeline:event-processor"]
 path = "wit/deps/timeline_event-processor"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -7,14 +7,14 @@ version = "0.0.1"
 world = "driver"
 path = "wit"
 
-[package.metadata.component.target.dependencies."timeline:core"]
-path = "wit/deps/timeline_core"
-
 [package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
 path = "wit/deps/timeline_timeline-processor-stub"
 
 [package.metadata.component.target.dependencies."timeline:timeline-processor"]
 path = "wit/deps/timeline_timeline-processor"
+
+[package.metadata.component.target.dependencies."timeline:event-processor"]
+path = "wit/deps/timeline_event-processor"
 
 [package.metadata.component.target.dependencies."timeline:event-processor-stub"]
 path = "wit/deps/timeline_event-processor-stub"
@@ -22,11 +22,11 @@ path = "wit/deps/timeline_event-processor-stub"
 [package.metadata.component.target.dependencies."timeline:core-stub"]
 path = "wit/deps/timeline_core-stub"
 
+[package.metadata.component.target.dependencies."timeline:core"]
+path = "wit/deps/timeline_core"
+
 [package.metadata.component.target.dependencies."golem:rpc"]
 path = "wit/deps/wasm-rpc"
-
-[package.metadata.component.target.dependencies."timeline:event-processor"]
-path = "wit/deps/timeline_event-processor"
 
 [dependencies]
 once_cell = "1.17.1"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.0.1"
 world = "driver"
 path = "wit"
 
-[package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
-path = "wit/deps/timeline_timeline-processor-stub"
+[package.metadata.component.target.dependencies."golem:rpc"]
+path = "wit/deps/wasm-rpc"
 
 [package.metadata.component.target.dependencies."timeline:timeline-processor"]
 path = "wit/deps/timeline_timeline-processor"
@@ -19,14 +19,14 @@ path = "wit/deps/timeline_event-processor"
 [package.metadata.component.target.dependencies."timeline:event-processor-stub"]
 path = "wit/deps/timeline_event-processor-stub"
 
+[package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
+path = "wit/deps/timeline_timeline-processor-stub"
+
 [package.metadata.component.target.dependencies."timeline:core-stub"]
 path = "wit/deps/timeline_core-stub"
 
 [package.metadata.component.target.dependencies."timeline:core"]
 path = "wit/deps/timeline_core"
-
-[package.metadata.component.target.dependencies."golem:rpc"]
-path = "wit/deps/wasm-rpc"
 
 [dependencies]
 once_cell = "1.17.1"

--- a/driver/src/builder.rs
+++ b/driver/src/builder.rs
@@ -1,0 +1,229 @@
+use crate::bindings::timeline::core::api::TimelineOp as WitTimeLineOp;
+use crate::bindings::timeline::core::api::{
+    NodeIndex, ServerWithEventColumnName, ServerWithEventPredicate, ServerWithEventPredicateWithin,
+    TimelineConstantComparator, TimelineConstantCompared, TimelineNegated, TimelineNode,
+    TimelineWithServer,
+};
+use crate::conversions::Conversion;
+use timeline::timeline_op::TimeLineOp;
+
+pub struct WitValueBuilder {
+    nodes: Vec<TimelineNode>,
+}
+
+impl WitValueBuilder {
+    pub(crate) fn new() -> Self {
+        WitValueBuilder { nodes: Vec::new() }
+    }
+
+    fn add(&mut self, node: TimelineNode) -> NodeIndex {
+        self.nodes.push(node);
+        self.nodes.len() as NodeIndex - 1
+    }
+
+    // FIXME: Clone is not needed
+    pub(crate) fn build(&self) -> WitTimeLineOp {
+        WitTimeLineOp { nodes: self.nodes.clone() }
+    }
+
+    pub(crate) fn build_timeline_op(&mut self, timeline_op: &TimeLineOp) -> NodeIndex {
+        match timeline_op {
+            TimeLineOp::TlHasExisted(timeline_worker_input, event_predicate) => {
+                let server = timeline_worker_input.to_wit();
+                let event_predicate = event_predicate.to_wit();
+
+                let timeline_node = TimelineNode::TlHasExisted(ServerWithEventPredicate {
+                    server,
+                    event_predicate,
+                });
+                self.add(timeline_node)
+            }
+
+            TimeLineOp::TlLatestEventToState(timeline_worker_input, event_column_name) => {
+                let server = timeline_worker_input.to_wit();
+                let event_column_name = event_column_name.0.clone();
+
+                let timeline_node = TimelineNode::TlLatestEventToState(ServerWithEventColumnName {
+                    server,
+                    event_column_name,
+                });
+                self.add(timeline_node)
+            }
+
+            TimeLineOp::Not(timeline_worker_input, timeline_op) => {
+                let server = timeline_worker_input.to_wit();
+                let parent_idx = self
+                    .add(TimelineNode::TimelineNegation(TimelineNegated { server, timeline: -1 }));
+
+                let child_idx = self.build_timeline_op(timeline_op);
+
+                match &mut self.nodes[parent_idx as usize] {
+                    TimelineNode::TimelineNegation(negated) => {
+                        negated.timeline = child_idx;
+                    }
+                    _ => unreachable!(),
+                }
+                parent_idx
+            }
+
+            TimeLineOp::GreaterThan(timeline_worker_input, timeline_op, golem_event_value) => {
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::GreaterThan,
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
+
+                let child_idx = self.build_timeline_op(timeline_op);
+
+                match &mut self.nodes[parent_idx as usize] {
+                    TimelineNode::TimelineComparison(timeline_constant_compared) => {
+                        timeline_constant_compared.timeline = child_idx;
+                    }
+                    _ => unreachable!(),
+                }
+
+                parent_idx
+            }
+
+            TimeLineOp::GreaterThanOrEqual(
+                timeline_worker_input,
+                timeline_op,
+                golem_event_value,
+            ) => {
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::GreaterThanEqual,
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
+
+                let child_idx = self.build_timeline_op(timeline_op);
+
+                match &mut self.nodes[parent_idx as usize] {
+                    TimelineNode::TimelineComparison(timeline_constant_compared) => {
+                        timeline_constant_compared.timeline = child_idx;
+                    }
+                    _ => unreachable!(),
+                }
+
+                parent_idx
+            }
+
+            TimeLineOp::LessThan(timeline_worker_input, timeline_op, golem_event_value) => {
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::LessThan,
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
+
+                let child_idx = self.build_timeline_op(timeline_op);
+
+                match &mut self.nodes[parent_idx as usize] {
+                    TimelineNode::TimelineComparison(timeline_constant_compared) => {
+                        timeline_constant_compared.timeline = child_idx;
+                    }
+                    _ => unreachable!(),
+                }
+
+                parent_idx
+            }
+
+            TimeLineOp::LessThanOrEqual(timeline_worker_input, timeline_op, golem_event_value) => {
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::LessThanEqual,
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
+
+                let child_idx = self.build_timeline_op(timeline_op);
+
+                match &mut self.nodes[parent_idx as usize] {
+                    TimelineNode::TimelineComparison(timeline_constant_compared) => {
+                        timeline_constant_compared.timeline = child_idx;
+                    }
+                    _ => unreachable!(),
+                }
+
+                parent_idx
+            }
+
+            TimeLineOp::EqualTo(timeline_worker_input, timeline_op, golem_event_value) => {
+                let parent_idx =
+                    self.add(TimelineNode::TimelineComparison(TimelineConstantCompared {
+                        op: TimelineConstantComparator::GreaterThan, // FIXME: Add Equal to ConstantOp
+                        timeline: -1,
+                        value: golem_event_value.to_wit(),
+                        server: timeline_worker_input.to_wit(),
+                    }));
+
+                let child_idx = self.build_timeline_op(timeline_op);
+
+                match &mut self.nodes[parent_idx as usize] {
+                    TimelineNode::TimelineComparison(timeline_constant_compared) => {
+                        timeline_constant_compared.timeline = child_idx;
+                    }
+                    _ => unreachable!(),
+                }
+
+                parent_idx
+            }
+
+            TimeLineOp::TlDurationInCurState(timeline_worker_input, timeline_op) => {
+                let parent_idx = self.add(TimelineNode::TlDurationInCurState(TimelineWithServer {
+                    server: timeline_worker_input.to_wit(),
+                    timeline: -1,
+                }));
+
+                let child_idx = self.build_timeline_op(timeline_op);
+
+                match &mut self.nodes[parent_idx as usize] {
+                    TimelineNode::TlDurationInCurState(ref mut timeline) => {
+                        timeline.timeline = child_idx;
+                    }
+                    _ => unreachable!(),
+                }
+
+                parent_idx
+            }
+
+            TimeLineOp::TlDurationWhere(timeline_worker_input, timeline_op) => {
+                let parent_idx = self.add(TimelineNode::TlDurationWhere(TimelineWithServer {
+                    server: timeline_worker_input.to_wit(),
+                    timeline: -1,
+                }));
+
+                let child_idx = self.build_timeline_op(timeline_op);
+
+                match &mut self.nodes[parent_idx as usize] {
+                    TimelineNode::TlDurationWhere(timeline) => {
+                        timeline.timeline = child_idx;
+                    }
+                    _ => unreachable!(),
+                }
+
+                parent_idx
+            }
+            TimeLineOp::TlHasExistedWithin(timeline_worker_input, event_predicate, time) => self
+                .add(TimelineNode::TlHasExistedWithin(ServerWithEventPredicateWithin {
+                    filtered: ServerWithEventPredicate {
+                        server: timeline_worker_input.to_wit(),
+                        event_predicate: event_predicate.to_wit(),
+                    },
+                    time: *time,
+                })),
+            TimeLineOp::And(_timeline_worker_input, _timeline_op1, _timeline_op2) => {
+                unimplemented!("And") //FIXME
+            }
+            TimeLineOp::Or(_, _, _) => {
+                unimplemented!("Or") //FIXME
+            }
+        }
+    }
+}

--- a/driver/src/conversions.rs
+++ b/driver/src/conversions.rs
@@ -1,96 +1,215 @@
 use std::fmt::Debug;
-use timeline::timeline_node_worker::{
-    TimeLineResultWorker, TimeLineWorkerId, TypedTimeLineResultWorker,
-};
+use timeline::event_predicate::{EventColumnName, EventColumnValue, GolemEventPredicate};
+use timeline::golem_event::GolemEventValue;
+use timeline::timeline_node_worker::{TimeLineNodeWorkerInput, TimeLineWorkerIdPrefix};
+use timeline::timeline_op::TimeLineOp;
 
-use crate::bindings::timeline::timeline_processor::api::DerivedTimelineNode as WitDerivedTimeLineNode;
-use crate::bindings::timeline::timeline_processor::api::LeafTimelineNode as WitLeafTimeLineNode;
-use crate::bindings::timeline::timeline_processor::api::TypedTimelineResultWorker as WitTypedTimeLineResultWorker;
+use crate::bindings::timeline::event_processor::api::EventPredicate as WitEventPredicate;
+
+use crate::bindings::timeline::core::api::Server as WitTimeLineNodeWorker;
+use crate::bindings::timeline::event_processor::api::EventValue as WitEventValue;
+
+use crate::bindings::timeline::core::api::TimelineOp as WitTimeLineOp;
+use crate::bindings::timeline::event_processor::api::EventPredicateOp;
+
+use crate::builder::WitValueBuilder;
 
 pub trait Conversion: Clone + Debug {
     type WitType: Clone;
-    fn _from_wit(input: Self::WitType) -> Self;
+    fn from_wit(input: Self::WitType) -> Self;
+    fn to_wit(&self) -> Self::WitType;
+}
+
+impl Conversion for GolemEventValue {
+    type WitType = WitEventValue;
+
+    fn from_wit(input: Self::WitType) -> Self {
+        match input {
+            WitEventValue::StringValue(value) => GolemEventValue::StringValue(value),
+            WitEventValue::IntValue(value) => GolemEventValue::IntValue(value),
+            WitEventValue::BoolValue(value) => GolemEventValue::BoolValue(value),
+            WitEventValue::FloatValue(value) => GolemEventValue::FloatValue(value),
+        }
+    }
+
+    fn to_wit(&self) -> Self::WitType {
+        match self {
+            GolemEventValue::StringValue(value) => WitEventValue::StringValue(value.clone()),
+            GolemEventValue::IntValue(value) => WitEventValue::IntValue(*value),
+            GolemEventValue::BoolValue(value) => WitEventValue::BoolValue(*value),
+            GolemEventValue::FloatValue(value) => WitEventValue::FloatValue(*value),
+        }
+    }
+}
+
+impl Conversion for GolemEventPredicate<GolemEventValue> {
+    type WitType = WitEventPredicate;
+
+    fn from_wit(input: Self::WitType) -> Self {
+        let event_column = EventColumnName(input.col_name.clone());
+        let event_value = EventColumnValue::from(GolemEventValue::from_wit(input.value.clone()));
+        match input.op {
+            EventPredicateOp::Equal => GolemEventPredicate::Equals(event_column, event_value),
+            EventPredicateOp::GreaterThan => {
+                GolemEventPredicate::GreaterThan(event_column, event_value)
+            }
+            EventPredicateOp::LessThan => GolemEventPredicate::LessThan(event_column, event_value),
+        }
+    }
+
+    fn to_wit(&self) -> Self::WitType {
+        match self {
+            GolemEventPredicate::Equals(event_column, event_value) => WitEventPredicate {
+                col_name: event_column.0.clone(),
+                value: event_value.0.to_wit(),
+                op: EventPredicateOp::Equal
+            },
+            GolemEventPredicate::GreaterThan(event_column, event_value) => WitEventPredicate {
+                col_name: event_column.0.clone(),
+                value: event_value.0.to_wit(),
+                op: EventPredicateOp::GreaterThan
+            },
+            GolemEventPredicate::LessThan(event_column, event_value) => WitEventPredicate {
+                col_name: event_column.0.clone(),
+                value: event_value.0.to_wit(),
+                op: EventPredicateOp::LessThan
+            },
+            _ => panic!("Not all possible event predicate represented in WIT. This will be included in near future")
+        }
+    }
+}
+
+impl Conversion for TimeLineNodeWorkerInput {
+    type WitType = WitTimeLineNodeWorker;
+
+    fn from_wit(input: Self::WitType) -> Self {
+        TimeLineNodeWorkerInput {
+            worker_id_prefix: TimeLineWorkerIdPrefix(input.worker_id_prefix),
+            component_id: input.template_id,
+        }
+    }
+
+    fn to_wit(&self) -> Self::WitType {
+        WitTimeLineNodeWorker {
+            worker_id_prefix: self.worker_id_prefix.0.clone(),
+            template_id: self.component_id.clone(),
+        }
+    }
 }
 
 // FIXME: This is repeated in core module because api::TypedTimeLineResultWorker is different because of binding differences
 
-impl Conversion for TypedTimeLineResultWorker {
-    type WitType = WitTypedTimeLineResultWorker;
+// TimeLineOp conversion
+impl Conversion for TimeLineOp {
+    type WitType = WitTimeLineOp;
 
-    fn _from_wit(input: Self::WitType) -> Self {
-        match input {
-            WitTypedTimeLineResultWorker::LeafTimeline(leaf_time_line) => match leaf_time_line {
-                WitLeafTimeLineNode::TlHasExisted(timeline_result_worker) => {
-                    TypedTimeLineResultWorker::tl_has_existed(TimeLineResultWorker {
-                        worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                        component_id: timeline_result_worker.template_id.clone(),
-                    })
-                }
-                WitLeafTimeLineNode::TlHasExistedWithin(timeline_result_worker) => {
-                    TypedTimeLineResultWorker::tl_has_existed_within(TimeLineResultWorker {
-                        worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                        component_id: timeline_result_worker.template_id.clone(),
-                    })
-                }
-                WitLeafTimeLineNode::TlLatestEventToState(timeline_result_worker) => {
-                    TypedTimeLineResultWorker::tl_event_to_latest_state(TimeLineResultWorker {
-                        worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                        component_id: timeline_result_worker.template_id.clone(),
-                    })
-                }
-            },
+    fn from_wit(input: Self::WitType) -> Self {
+        assert!(!input.nodes.is_empty());
+        internals::build_timeline_tree(&input.nodes[0], &input.nodes)
+    }
 
-            WitTypedTimeLineResultWorker::DerivedTimeline(derived_timeline) => {
-                match derived_timeline {
-                    WitDerivedTimeLineNode::EqualTo(timeline_result_worker) => {
-                        TypedTimeLineResultWorker::equal_to(TimeLineResultWorker {
-                            worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                            component_id: timeline_result_worker.template_id.clone(),
-                        })
-                    }
-                    WitDerivedTimeLineNode::GreaterThan(timeline_result_worker) => {
-                        TypedTimeLineResultWorker::greater_than(TimeLineResultWorker {
-                            worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                            component_id: timeline_result_worker.template_id.clone(),
-                        })
-                    }
-                    WitDerivedTimeLineNode::GreaterThanOrEqualTo(timeline_result_worker) => {
-                        TypedTimeLineResultWorker::greater_than_or_equal_to(TimeLineResultWorker {
-                            worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                            component_id: timeline_result_worker.template_id.clone(),
-                        })
-                    }
-                    WitDerivedTimeLineNode::LessThan(timeline_result_worker) => {
-                        TypedTimeLineResultWorker::less_than(TimeLineResultWorker {
-                            worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                            component_id: timeline_result_worker.template_id.clone(),
-                        })
-                    }
-                    WitDerivedTimeLineNode::LessThanOrEqualTo(timeline_result_worker) => {
-                        TypedTimeLineResultWorker::less_than_or_equal_to(TimeLineResultWorker {
-                            worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                            component_id: timeline_result_worker.template_id.clone(),
-                        })
-                    }
-                    WitDerivedTimeLineNode::And(timeline_result_worker) => {
-                        TypedTimeLineResultWorker::and(TimeLineResultWorker {
-                            worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                            component_id: timeline_result_worker.template_id.clone(),
-                        })
-                    }
-                    WitDerivedTimeLineNode::Or(timeline_result_worker) => {
-                        TypedTimeLineResultWorker::or(TimeLineResultWorker {
-                            worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                            component_id: timeline_result_worker.template_id.clone(),
-                        })
-                    }
-                    WitDerivedTimeLineNode::Not(timeline_result_worker) => {
-                        TypedTimeLineResultWorker::not(TimeLineResultWorker {
-                            worker_id: TimeLineWorkerId(timeline_result_worker.worker_id.clone()),
-                            component_id: timeline_result_worker.template_id.clone(),
-                        })
-                    }
+    fn to_wit(&self) -> Self::WitType {
+        let mut builder = WitValueBuilder::new();
+        builder.build_timeline_op(self);
+        builder.build()
+    }
+}
+
+mod internals {
+    use timeline::event_predicate::{EventColumnName, GolemEventPredicate};
+    use timeline::golem_event::GolemEventValue;
+    use timeline::timeline_node_worker::TimeLineNodeWorkerInput;
+    use timeline::timeline_op::TimeLineOp;
+
+    use crate::bindings::timeline::core::api::{
+        TimelineConstantComparator, TimelineNode as WitTimeLineNode, TimelineNode,
+    };
+
+    use super::Conversion;
+
+    pub(crate) fn build_timeline_tree(node: &TimelineNode, nodes: &[TimelineNode]) -> TimeLineOp {
+        match node {
+            WitTimeLineNode::TimelineComparison(timeline_constant_compared) => {
+                let time_line = build_timeline_tree(
+                    &nodes[timeline_constant_compared.timeline as usize],
+                    nodes,
+                );
+                let golem_event_value: GolemEventValue =
+                    GolemEventValue::from_wit(timeline_constant_compared.value.clone());
+                let timeline_node_worker =
+                    TimeLineNodeWorkerInput::from_wit(timeline_constant_compared.server.clone());
+
+                match timeline_constant_compared.op {
+                    TimelineConstantComparator::GreaterThan => TimeLineOp::GreaterThan(
+                        timeline_node_worker,
+                        Box::new(time_line),
+                        golem_event_value,
+                    ),
+                    TimelineConstantComparator::GreaterThanEqual => TimeLineOp::GreaterThanOrEqual(
+                        timeline_node_worker,
+                        Box::new(time_line),
+                        golem_event_value,
+                    ),
+                    TimelineConstantComparator::LessThan => TimeLineOp::LessThan(
+                        timeline_node_worker,
+                        Box::new(time_line),
+                        golem_event_value,
+                    ),
+                    TimelineConstantComparator::LessThanEqual => TimeLineOp::LessThanOrEqual(
+                        timeline_node_worker,
+                        Box::new(time_line),
+                        golem_event_value,
+                    ),
                 }
+            }
+            WitTimeLineNode::TimelineNegation(timeline_negation) => {
+                let time_line =
+                    build_timeline_tree(&nodes[timeline_negation.timeline as usize], nodes);
+                let timeline_node_worker: TimeLineNodeWorkerInput =
+                    TimeLineNodeWorkerInput::from_wit(timeline_negation.server.clone());
+
+                TimeLineOp::Not(timeline_node_worker, Box::new(time_line))
+            }
+            WitTimeLineNode::TlHasExisted(server_with_event_predicate) => {
+                let server: TimeLineNodeWorkerInput =
+                    TimeLineNodeWorkerInput::from_wit(server_with_event_predicate.server.clone());
+                let filter = GolemEventPredicate::from_wit(
+                    server_with_event_predicate.event_predicate.clone(),
+                );
+                TimeLineOp::TlHasExisted(server, filter)
+            }
+
+            WitTimeLineNode::TlHasExistedWithin(server_with_event_predicate_within) => {
+                let max_duration = server_with_event_predicate_within.time;
+                let server: TimeLineNodeWorkerInput = TimeLineNodeWorkerInput::from_wit(
+                    server_with_event_predicate_within.filtered.server.clone(),
+                );
+
+                let filter = GolemEventPredicate::from_wit(
+                    server_with_event_predicate_within.filtered.event_predicate.clone(),
+                );
+
+                TimeLineOp::TlHasExistedWithin(server, filter, max_duration)
+            }
+            WitTimeLineNode::TlDurationWhere(tl) => {
+                let time_line = build_timeline_tree(&nodes[tl.timeline as usize], nodes);
+
+                TimeLineOp::TlDurationWhere(
+                    TimeLineNodeWorkerInput::from_wit(tl.server.clone()),
+                    Box::new(time_line),
+                )
+            }
+            WitTimeLineNode::TlDurationInCurState(tl) => {
+                let time_line = build_timeline_tree(&nodes[tl.timeline as usize], nodes);
+                let timeline_node_worker = TimeLineNodeWorkerInput::from_wit(tl.server.clone());
+                TimeLineOp::TlDurationInCurState(timeline_node_worker, Box::new(time_line))
+            }
+            TimelineNode::TlLatestEventToState(server_with_event_column_name) => {
+                let server =
+                    TimeLineNodeWorkerInput::from_wit(server_with_event_column_name.server.clone());
+                let event_column_name =
+                    EventColumnName(server_with_event_column_name.event_column_name.clone());
+                TimeLineOp::TlLatestEventToState(server, event_column_name)
             }
         }
     }

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -41,9 +41,7 @@ impl Guest for Component {
             )),
         );
 
-        let foo = &simple_timeline.to_wit();
-
-        match core.initialize_timeline(foo) {
+        match core.initialize_timeline(&simple_timeline.to_wit()) {
             Ok(result) => {
                 dbg!("Driver Log: Timeline initialized");
                 Ok(result)

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -1,48 +1,49 @@
 use crate::bindings::exports::timeline::driver::api::Guest;
 use crate::bindings::golem::rpc::types::Uri;
-use crate::bindings::timeline::core::api::TimelineNode::{TimelineNegation, TlLatestEventToState};
-use crate::bindings::timeline::core::api::{Server, WorkerDetails};
-use crate::bindings::timeline::core::api::{
-    ServerWithEventColumnName, TimelineNegated, TimelineOp,
-};
+
+use crate::bindings::timeline::core::api::WorkerDetails;
+
 use crate::bindings::timeline::core_stub::stub_core;
 
+use conversions::Conversion;
+use timeline::event_predicate::EventColumnName as DslEventColumnName;
+use timeline::timeline_node_worker::TimeLineNodeWorkerInput as DslTimeLineNodeWorkerInput;
+use timeline::timeline_node_worker::TimeLineWorkerIdPrefix as DslTimeLineWorkerIdPrefix;
+use timeline::timeline_op::TimeLineOp as DslTimeLineOp;
 
 #[allow(dead_code)]
 #[rustfmt::skip]
 mod bindings;
+mod builder;
 mod conversions;
 struct Component;
 
 impl Guest for Component {
     fn run(
         core_template_id: String,
-        event_processor_template_id: String,
-        timeline_processor_template_id: String,
+        event_processor_component_id: String,
+        timeline_processor_component_id: String,
     ) -> Result<WorkerDetails, String> {
         let uri = Uri { value: format!("worker://{core_template_id}/{}", "initialize-timeline") };
 
         let core = stub_core::Api::new(&uri);
-        let timeline_op = TimelineOp {
-            nodes: vec![
-                TimelineNegation(TimelineNegated {
-                    server: Server {
-                        template_id: timeline_processor_template_id.to_string(),
-                        worker_id_prefix: "cirr".to_string(),
-                    },
-                    timeline: 1,
-                }),
-                TlLatestEventToState(ServerWithEventColumnName {
-                    server: Server {
-                        template_id: event_processor_template_id.to_string(),
-                        worker_id_prefix: "cirr".to_string(),
-                    },
-                    event_column_name: "playerStateChange".to_string(),
-                }),
-            ],
-        };
+        let simple_timeline = DslTimeLineOp::Not(
+            DslTimeLineNodeWorkerInput {
+                worker_id_prefix: DslTimeLineWorkerIdPrefix("not".to_string()),
+                component_id: timeline_processor_component_id,
+            },
+            Box::new(DslTimeLineOp::TlLatestEventToState(
+                DslTimeLineNodeWorkerInput {
+                    worker_id_prefix: DslTimeLineWorkerIdPrefix("cdn-change".to_string()),
+                    component_id: event_processor_component_id,
+                },
+                DslEventColumnName("cdnChange".to_string()),
+            )),
+        );
 
-        match core.initialize_timeline(&timeline_op) {
+        let foo = &simple_timeline.to_wit();
+
+        match core.initialize_timeline(foo) {
             Ok(result) => {
                 dbg!("Driver Log: Timeline initialized");
                 Ok(result)

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -30,15 +30,15 @@ impl Guest for Component {
         let core = stub_core::Api::new(&uri);
         let simple_timeline = DslTimeLineOp::Not(
             DslTimeLineNodeWorkerInput {
-                worker_id_prefix: DslTimeLineWorkerIdPrefix("not".to_string()),
+                worker_id_prefix: DslTimeLineWorkerIdPrefix("cirr".to_string()),
                 component_id: timeline_processor_component_id,
             },
             Box::new(DslTimeLineOp::TlLatestEventToState(
                 DslTimeLineNodeWorkerInput {
-                    worker_id_prefix: DslTimeLineWorkerIdPrefix("cdn-change".to_string()),
+                    worker_id_prefix: DslTimeLineWorkerIdPrefix("cirr".to_string()),
                     component_id: event_processor_component_id,
                 },
-                DslEventColumnName("cdnChange".to_string()),
+                DslEventColumnName("playerStateChange".to_string()),
             )),
         );
 

--- a/driver/src/lib.rs
+++ b/driver/src/lib.rs
@@ -14,17 +14,18 @@ use timeline::timeline_op::TimeLineOp as DslTimeLineOp;
 #[allow(dead_code)]
 #[rustfmt::skip]
 mod bindings;
+
 mod builder;
 mod conversions;
 struct Component;
 
 impl Guest for Component {
     fn run(
-        core_template_id: String,
+        core_component_id: String,
         event_processor_component_id: String,
         timeline_processor_component_id: String,
     ) -> Result<WorkerDetails, String> {
-        let uri = Uri { value: format!("worker://{core_template_id}/{}", "initialize-timeline") };
+        let uri = Uri { value: format!("worker://{core_component_id}/{}", "initialize-timeline") };
 
         let core = stub_core::Api::new(&uri);
         let simple_timeline = DslTimeLineOp::Not(

--- a/event-processor/Cargo.toml
+++ b/event-processor/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [lib]
 path = "src/lib.rs"
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [dependencies]
 timeline = { path = "../timeline" }

--- a/timeline-processor/Cargo.toml
+++ b/timeline-processor/Cargo.toml
@@ -10,14 +10,14 @@ path = "wit"
 [package.metadata.component.target.dependencies."timeline:event-processor"]
 path = "wit/deps/timeline_event-processor"
 
+[package.metadata.component.target.dependencies."timeline:event-processor-stub"]
+path = "wit/deps/timeline_event-processor-stub"
+
 [package.metadata.component.target.dependencies."golem:rpc"]
 path = "wit/deps/wasm-rpc"
 
 [package.metadata.component.target.dependencies."timeline:timeline-processor-stub"]
 path = "wit/deps/timeline_timeline-processor-stub"
-
-[package.metadata.component.target.dependencies."timeline:event-processor-stub"]
-path = "wit/deps/timeline_event-processor-stub"
 
 [dependencies]
 once_cell = "1.17.1"


### PR DESCRIPTION
This PR produces following plan

```
{
  "event-processor-workers": [
    {
      "leaf-timeline": {
        "tl-has-existed-within": {
          "template-id": "020a0063-594e-4133-922d-d13ac9f3cff3",
          "worker-id": "cirr-le2s-playerStateChange"
        }
      }
    }
  ],
  "result-worker": {
    "derived-timeline": {
      "not": {
        "template-id": "a434cf12-e460-497a-a4c7-0682024b9808",
        "worker-id": "cirr-tl-not-b7badd9e-077f-408c-a501-fa4d008dadc0"
      }
    }
  }
}
```

And
```
golem-cli worker invoke-and-await  --component-id 020a0063-594e-4133-922d-d13ac9f3cff3 --worker-name cirr-le2s-playerStateChange --function timeline:event-processor/api/latest-event-to-state --parameters '[3]'
Invocation results in WAVE format:
- 'ok({results: [{time-period: {t1: 2, t2: 3}, value: string-value("seek")}]})'
```