### PR TITLE
Fix

### DIFF
--- a/quick_test.sh
+++ b/quick_test.sh
@@ -28,6 +28,15 @@ echo "Exposing Timeline as API for users..."
 
 response_body='{ body: match worker.response[0] { ok(value) => value, err(msg) => msg }, status: match worker.response[0]{ ok(_) => 200, err(_) => 500 } }'
 
+program = '
+ let result = timeline:driver/api/run(REPLACE_CORE_WITH_EVENT_WITH_TIMELINE, REPLACE_EVENT_PROCESSOR, REPLACE_TIMELINE_WITH_EVENT_WITH_TIMELINE);
+ let body = match result { ok(value) => value, err(msg) => msg }
+ let status = match worker.response { ok(_) => 200, err(_) => 500 }
+ { body, status }
+'
+program="${expression/REPLACE_CORE_WITH_EVENT_WITH_TIMELINE/$core_with_event_with_timeline}"
+program="${expression/REPLACE_EVENT_PROCESSOR/$event_processor}"
+program="${expression/REPLACE_TIMELINE_WITH_EVENT_WITH_TIMELINE/$timeline_with_event_with_timeline}"
 
 api_definition='{
   "id": "golem-timeline",
@@ -41,9 +50,7 @@ api_definition='{
         "type": "wit-worker",
         "componentId": REPLACE_DRIVER_WITH_CORE,
         "workerName": "first-try",
-        "functionName": "timeline:driver/api/run",
-        "functionParams": [REPLACE_CORE_WITH_EVENT_WITH_TIMELINE, REPLACE_EVENT_PROCESSOR, REPLACE_TIMELINE_WITH_EVENT_WITH_TIMELINE],
-        "response" : "${ {body: match worker.response { ok(value) => value, err(msg) => msg }, status: match worker.response { ok(_) => 200, err(_) => 500 } }}"
+        "response" : "${EXPRESSION}"
       }
     }
   ]
@@ -52,9 +59,7 @@ api_definition='{
 # Replace placeholders with actual values
 api_definition="${api_definition/REPLACE_VERSION/$current_epoch}"
 api_definition="${api_definition/REPLACE_DRIVER_WITH_CORE/$driver_with_core}"
-api_definition="${api_definition/REPLACE_CORE_WITH_EVENT_WITH_TIMELINE/$core_with_event_with_timeline}"
-api_definition="${api_definition/REPLACE_EVENT_PROCESSOR/$event_processor}"
-api_definition="${api_definition/REPLACE_TIMELINE_WITH_EVENT_WITH_TIMELINE/$timeline_with_event_with_timeline}"
+api_definition="${api_definition/EXPRESSION/$program}"
 
 echo $api_definition
 

--- a/quick_test.sh
+++ b/quick_test.sh
@@ -31,7 +31,7 @@ response_body='{ body: match worker.response[0] { ok(value) => value, err(msg) =
 program = '
  let result = timeline:driver/api/run(REPLACE_CORE_WITH_EVENT_WITH_TIMELINE, REPLACE_EVENT_PROCESSOR, REPLACE_TIMELINE_WITH_EVENT_WITH_TIMELINE);
  let body = match result { ok(value) => value, err(msg) => msg }
- let status = match worker.response { ok(_) => 200, err(_) => 500 }
+ let status = match result { ok(_) => 200, err(_) => 500 }
  { body, status }
 '
 program="${expression/REPLACE_CORE_WITH_EVENT_WITH_TIMELINE/$core_with_event_with_timeline}"


### PR DESCRIPTION
Refer to wasm-wave syntax to learn `{a : '1', b: '2'}` is a record. Golem's requirement is, script should return a record of body and status.